### PR TITLE
CI Improve pre-commit setup and run it on the CI

### DIFF
--- a/.github/workflows/run_code_format_checks.yaml
+++ b/.github/workflows/run_code_format_checks.yaml
@@ -1,0 +1,21 @@
+name: Run code format checks
+on:
+  pull_request:
+  push: { branches: main }
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install pre-commit setup
+      run: |
+        pip install pre-commit
+        pre-commit install
+
+    - name: Run pre-commit checks
+      run: pre-commit run

--- a/.github/workflows/run_code_format_checks.yaml
+++ b/.github/workflows/run_code_format_checks.yaml
@@ -4,8 +4,8 @@ on:
   push: { branches: main }
 
 jobs:
-  test:
-    name: Run test suite
+  run-pre-commit-checks:
+    name: Run pre-commit checks
     runs-on: ubuntu-latest
 
     steps:
@@ -17,5 +17,5 @@ jobs:
         pip install pre-commit
         pre-commit install
 
-    - name: Run pre-commit checks
+    - name: Run checks
       run: pre-commit run

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install sklearn-numba-dpex
-      run: pip install -e . --no-build-isolation
+      run: pip install .
 
     - name: Check device
       run: python -c "import dpctl; dpctl.select_default_device().print_device_info()"

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -4,7 +4,7 @@ on:
   push: { branches: main }
 
 jobs:
-  test:
+  run-test-suite:
     name: Run test suite
     runs-on: ubuntu-latest
     container: jjerphan/numba_dpex_dev:latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
      -  id: mypy
         files: sklearn_numba_dpex/
         additional_dependencies: [pytest==6.2.4]
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort
+        files: sklearn_numba_dpex/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,61 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sklearn-numba-dpex"
+version = "0.1.0"
+description = "Computational Engine for scikit-learn based on numba-dpex"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { file="LICENSE.txt" }
+maintainers = [
+  { name="Olivier Grisel", email="olivier.grisel@ensta.org" },
+]
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved",
+    "Programming Language :: Python",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering",
+    "Development Status :: 4 - Beta",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython"
+]
+
+
+# TODO: remove pyopencl when dpctl exposes preferred_work_group_size_multiple
+# see https://github.com/IntelPython/dpctl/issues/886
+dependencies = [
+    "scikit-learn",
+    "numba-dpex",
+    "dpctl",
+    "pyopencl"
+]
+
+
+[project.optional-dependencies]
+benchmark = [
+    "scikit-learn-intelex",
+    "pandas"
+]
+
+
+[project.urls]
+"Homepage" = "https://github.com/ogrisel/sklearn-numba-dpex"
+
+
+[project.entry-points.sklearn_engines]
+kmeans = "sklearn_numba_dpex.cluster.kmeans:KMeansEngine"
+
 [tool.black]
 line-length = 88
 target_version = ['py38', 'py39', 'py310']
@@ -18,3 +76,6 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+
+
+# TODO: move sections from setup.cfg to pyproject.toml when applicable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = [
+    "scikit-learn",
+    "numba-dpex",
+    "dpctl",
+    "pyopencl",
+]
+
+[tool.black]
+line-length = 88
+target_version = ['py38', 'py39', 'py310']
+preview = true
+# Exclude irrelevant directories for formatting
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.mypy_cache
+  | \.vscode
+  | \.pytest_cache
+  | \.idea
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,3 @@
-[build-system]
-# Minimum requirements for the build system to execute.
-requires = [
-    "scikit-learn",
-    "numba-dpex",
-    "dpctl",
-    "pyopencl",
-]
-
 [tool.black]
 line-length = 88
 target_version = ['py38', 'py39', 'py310']

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     # TODO: remove pyopencl when dpctl exposes preferred_work_group_size_multiple
     # see https://github.com/IntelPython/dpctl/issues/886
     install_requires=["scikit-learn", "numba-dpex", "dpctl", "pyopencl"],
-    extras_require=[dict(benchmark=["scikit-learn-intelex, pandas"])],
+    extras_require=dict(benchmark=["scikit-learn-intelex", "pandas"]),
     packages=["sklearn_numba_dpex"],
     entry_points={
         "sklearn_engines": ["kmeans=sklearn_numba_dpex.cluster.kmeans:KMeansEngine"]

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,6 @@
 from setuptools import setup
 
 
-LONG_DESCRIPTION = """\
-TODO
-"""
-
-
 setup(
-    name="sklearn-numba-dpex",
-    maintainer="Olivier Grisel",
-    maintainer_email="olivier.grisel@ensta.org",
-    description="Computational Engine for scikit-learn based on numba-dpex",
-    license="BSD 3-Clause License",
-    url="https://github.com/ogrisel/sklearn-numba-dpex",
-    version="0.1.0",
-    long_description=LONG_DESCRIPTION,
-    classifiers=[
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved",
-        "Programming Language :: Python",
-        "Topic :: Software Development",
-        "Topic :: Scientific/Engineering",
-        "Development Status :: 4 - Beta",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX",
-        "Operating System :: Unix",
-        "Operating System :: MacOS",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-    ],
-    python_requires=">=3.8",
-    # TODO: remove pyopencl when dpctl exposes preferred_work_group_size_multiple
-    # see https://github.com/IntelPython/dpctl/issues/886
-    install_requires=["scikit-learn", "numba-dpex", "dpctl", "pyopencl"],
-    extras_require=dict(benchmark=["scikit-learn-intelex", "pandas"]),
     packages=["sklearn_numba_dpex"],
-    entry_points={
-        "sklearn_engines": ["kmeans=sklearn_numba_dpex.cluster.kmeans:KMeansEngine"]
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     # TODO: remove pyopencl when dpctl exposes preferred_work_group_size_multiple
     # see https://github.com/IntelPython/dpctl/issues/886
     install_requires=["scikit-learn", "numba-dpex", "dpctl", "pyopencl"],
-    extra_require=[dict(benchmark=["scikit-learn-intelex, pandas"])],
+    extras_require=[dict(benchmark=["scikit-learn-intelex, pandas"])],
     packages=["sklearn_numba_dpex"],
     entry_points={
         "sklearn_engines": ["kmeans=sklearn_numba_dpex.cluster.kmeans:KMeansEngine"]

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,9 @@ setup(
     # TODO: remove pyopencl when dpctl exposes preferred_work_group_size_multiple
     # see https://github.com/IntelPython/dpctl/issues/886
     install_requires=["scikit-learn", "numba-dpex", "dpctl", "pyopencl"],
-    extra_requires=[dict(benchmark=["scikit-learn-intelex, pandas"])],
+    extra_require=[dict(benchmark=["scikit-learn-intelex, pandas"])],
     packages=["sklearn_numba_dpex"],
     entry_points={
-        "sklearn_engines": [
-            "kmeans=sklearn_numba_dpex.cluster.kmeans:KMeansEngine"
-        ]
+        "sklearn_engines": ["kmeans=sklearn_numba_dpex.cluster.kmeans:KMeansEngine"]
     },
 )

--- a/sklearn_numba_dpex/tests/test_kmeans.py
+++ b/sklearn_numba_dpex/tests/test_kmeans.py
@@ -1,19 +1,17 @@
-import pytest
 import inspect
 
-import sklearn
 import dpctl
-
 import numpy as np
+import pytest
+import sklearn
 from numpy.testing import assert_array_equal
 from sklearn import config_context
-from sklearn.datasets import make_blobs
-from sklearn.cluster import KMeans
 from sklearn.base import clone
+from sklearn.cluster import KMeans
+from sklearn.datasets import make_blobs
 from sklearn.utils._testing import assert_allclose
 
 from sklearn_numba_dpex.kmeans.drivers import LLoydKMeansDriver
-
 
 _SKLEARN_LLOYD = sklearn.cluster._kmeans._kmeans_single_lloyd
 _SKLEARN_LLOYD_SIGNATURE = inspect.signature(_SKLEARN_LLOYD)
@@ -31,7 +29,7 @@ def _fail_if_no_dtype_support(xfail_fn, dtype):
     if dtype not in _SUPPORTED_DTYPE:
         xfail_fn(
             f"The default device {_DEVICE_NAME} does not have support for "
-            f"float64 operations."
+            "float64 operations."
         )
 
 

--- a/sklearn_numba_dpex/utils/_device.py
+++ b/sklearn_numba_dpex/utils/_device.py
@@ -1,6 +1,5 @@
 import warnings
 
-
 # TODO: when dpctl.SyclDevice also exposes relevant attributes,
 # remove the dependency to opencl and only use dpctl.
 # A unittest in test_device_params check the availability of the relevant
@@ -93,16 +92,17 @@ def _get_cl_param(cl_device, value, default, device_name):
 def _warns_missing_cl_param(value, default, device_name):
     text = [
         f"Trying to fetch the parameter {value} for the executing device {device_name} "
-        f"from opencl interface "
+        "from opencl interface "
     ]
     if pyopencl is None:
         text.append("with pyopencl, but pyopencl is missing.")
     else:
         text.append(
-            "but opencl can't find the device. Ensure the opencl drivers are available on the "
-            "system for this device."
+            "but opencl can't find the device. Ensure the opencl drivers are available"
+            " on the system for this device."
         )
     text.append(
-        f"\nUsing default value {value} = {default} as a fallback, which might be inadapted."
+        f"\nUsing default value {value} = {default} as a fallback, which might be"
+        " inadapted."
     )
     warnings.warn("".join(text), RuntimeWarning)

--- a/sklearn_numba_dpex/utils/tests/test_device_params.py
+++ b/sklearn_numba_dpex/utils/tests/test_device_params.py
@@ -1,8 +1,8 @@
-import pytest
 import warnings
+from dataclasses import dataclass
 
 import dpctl
-from dataclasses import dataclass
+import pytest
 
 from sklearn_numba_dpex.utils._device import _DeviceParams
 


### PR DESCRIPTION
This:
 - tune black correctly
 - use `isort` to sort import canonically
 - add a GitHub workflow to run format checks

Potentially we could have a single workflow with two jobs (one for those checks and another for the CI). What do you think?