### PR TITLE
Detect empty clusters during lloyd algorithm and issue a warning

### DIFF
--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -316,6 +316,7 @@ class LLoydKMeansDriver:
             n_clusters, dtype=np.uint32, device=self.device
         )
 
+        # nb_empty_clusters_ is a scalar handled in kernels via a one-element array.
         nb_empty_clusters = dpctl.tensor.empty(1, dtype=np.int32, device=self.device)
 
         # The loop

--- a/sklearn_numba_dpex/kmeans/kernels/__init__.py
+++ b/sklearn_numba_dpex/kmeans/kernels/__init__.py
@@ -4,6 +4,7 @@ from .lloyd_single_step import make_lloyd_single_step_fixed_window_kernel
 from .compute_labels_inertia import make_compute_labels_inertia_fixed_window_kernel
 from .utils import (
     make_centroid_shifts_kernel,
+    make_reduce_centroid_data_kernel,
     make_initialize_to_zeros_1d_kernel,
     make_initialize_to_zeros_2d_kernel,
     make_initialize_to_zeros_3d_kernel,
@@ -11,8 +12,6 @@ from .utils import (
     make_broadcast_division_1d_2d_kernel,
     make_half_l2_norm_2d_axis0_kernel,
     make_sum_reduction_1d_kernel,
-    make_sum_reduction_2d_axis0_kernel,
-    make_sum_reduction_3d_axis0_kernel,
 )
 
 
@@ -20,6 +19,7 @@ __all__ = (
     make_lloyd_single_step_fixed_window_kernel,
     make_compute_labels_inertia_fixed_window_kernel,
     make_centroid_shifts_kernel,
+    make_reduce_centroid_data_kernel,
     make_initialize_to_zeros_1d_kernel,
     make_initialize_to_zeros_2d_kernel,
     make_initialize_to_zeros_3d_kernel,
@@ -27,6 +27,4 @@ __all__ = (
     make_broadcast_division_1d_2d_kernel,
     make_half_l2_norm_2d_axis0_kernel,
     make_sum_reduction_1d_kernel,
-    make_sum_reduction_2d_axis0_kernel,
-    make_sum_reduction_3d_axis0_kernel,
 )

--- a/sklearn_numba_dpex/tests/test_kmeans.py
+++ b/sklearn_numba_dpex/tests/test_kmeans.py
@@ -88,6 +88,8 @@ def test_kmeans_fit_empty_clusters(dtype):
     n_clusters = inspect.signature(KMeans).parameters["n_clusters"].default
     rng = default_rng(random_seed)
     init = np.array(rng.choice(X, n_clusters, replace=False), dtype=np.float32)
+    # Create an outlier centroid in initial centroids
+    # to have an empty cluster.
     init[0] = np.finfo(np.float32).max
 
     kmeans_with_empty_cluster = KMeans(


### PR DESCRIPTION
This is a first step toward appropriate dealing of empty clusters.

In this PR we detect empty clusters when it happens during the lloyd algorithm and issue a warning when it happens.

Future work will implement the exact behavior that we have in scikit learn. In the short term I want to prioritize the plugin interface and probably will come to empty clusters only afterward (or maybe somebody else want to give it a try before me)

But since I had this part pending I think we could merge it already.
