### PR TITLE
Extend sum reduction kernel, add argmin reduction kernel

### DIFF
--- a/sklearn_numba_dpex/common/_utils.py
+++ b/sklearn_numba_dpex/common/_utils.py
@@ -1,0 +1,7 @@
+import math
+
+
+def check_power_of_2(e):
+    if e != 2 ** (math.log2(e)):
+        raise ValueError(f"Expected a power of 2, got {e}")
+    return e

--- a/sklearn_numba_dpex/common/kernels.py
+++ b/sklearn_numba_dpex/common/kernels.py
@@ -131,9 +131,11 @@ def make_half_l2_norm_2d_axis0_kernel(size0, size1, work_group_size, dtype):
 
 @lru_cache
 def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dtype):
-    """numba_dpex does not provide tools such as `cuda.reduce` so we implement from
-    scratch a reduction strategy. The strategy relies on the commutativity of the
-    operation used for the reduction, thus allowing to reduce the input in any order.
+    """Implement data_2d.sum(axis=1) or data_1d.sum()
+
+    numba_dpex does not provide tools such as `cuda.reduce` so we implement from scratch
+    a reduction strategy. The strategy relies on the commutativity of the operation used
+    for the reduction, thus allowing to reduce the input in any order.
 
     The strategy consists in performing local reductions in each work group using local
     memory where each work item combine two values, thus halving the number of values,

--- a/sklearn_numba_dpex/common/kernels.py
+++ b/sklearn_numba_dpex/common/kernels.py
@@ -147,30 +147,32 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
     `2 * work_group_size`. This is repeated as many time as needed until only one value
     remains in global memory.
 
-    NB: work_group_size is assumed to be a power of 2.
+    Notes
+    -----
+    `work_group_size` is assumed to be a power of 2.
 
-    NB: if size1 is None then the kernel expects 1d tensor inputs. If size1 is not None
-    then the expected shape of input tensors is (size0, size1), and the reduction
+    if `size1` is None then the kernel expects 1d tensor inputs. If `size1` is not None
+    then the expected shape of input tensors is `(size0, size1)`, and the reduction
     operation is equivalent to input.sum(axis=1). In this case, the kernel is a good
-    choice if size1 >> preferred_work_group_size_multiple, and if size0 ranges in the
-    same order of magnitude than preferred_work_group_size_multiple. If not, other
-    reduction implementations might give better performances.
-
-    ???: how does this strategy compares to having each thread reducing N contiguous
-    items ?
+    choice if `size1` >> `preferred_work_group_size_multiple`, and if `size0` ranges in
+    the same order of magnitude than `preferred_work_group_size_multiple`. If not,
+    other reduction implementations might give better performances.
     """
     # Number of iteration in each execution of the kernel:
     local_n_iterations = np.int64(math.floor(math.log2(work_group_size)) - 1)
 
     zero = dtype(0.0)
-    two_long = np.int64(2)
     one_idx = np.int64(1)
+    minus_one_idx = np.int64(-1)
+    two_as_a_long = np.int64(2)
 
     is_1d = size1 is None
+    # TODO: this set of kernel functions could be abstracted away to other coalescing
+    # functions
     if is_1d:
         sum_axis_size = size0
         n_rows = np.int64(1)
-        local_data_size = work_group_size
+        local_values_size = work_group_size
 
         @dpex.func
         def set_col_to_zero(array, i):
@@ -181,7 +183,7 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
             to_array[to_col] = from_array[from_col]
 
         @dpex.func
-        def coalesce_cols(
+        def add_cols(
             from_array,
             left_from_col,
             right_from_col,
@@ -191,7 +193,7 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
             to_array[to_col] = from_array[left_from_col] + from_array[right_from_col]
 
         @dpex.func
-        def coalesce_cols_inplace(
+        def add_cols_inplace(
             array,
             from_col,
             to_col,
@@ -199,13 +201,13 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
             array[to_col] += array[from_col]
 
         @dpex.func
-        def coalesce_first_cols(from_array, to_array, to_col):
+        def add_first_cols(from_array, to_array, to_col):
             to_array[to_col] = from_array[zero_idx] + from_array[one_idx]
 
     else:
         sum_axis_size = size1
         n_rows = size0
-        local_data_size = (size0, work_group_size)
+        local_values_size = (size0, work_group_size)
 
         @dpex.func
         def set_col_to_zero(array, i):
@@ -218,7 +220,7 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
                 to_array[row, to_col] = from_array[row, from_col]
 
         @dpex.func
-        def coalesce_cols(
+        def add_cols(
             from_array,
             left_from_col,
             right_from_col,
@@ -231,7 +233,7 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
                 )
 
         @dpex.func
-        def coalesce_cols_inplace(
+        def add_cols_inplace(
             array,
             from_col,
             to_col,
@@ -240,18 +242,17 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
                 array[row, to_col] += array[row, from_col]
 
         @dpex.func
-        def coalesce_first_cols(from_array, to_array, to_col):
+        def add_first_cols(from_array, to_array, to_col):
             for row in range(n_rows):
                 to_array[row, to_col] = (
                     from_array[row, zero_idx] + from_array[row, one_idx]
                 )
 
-    two_long = np.int64(2)
-    m_one_idx = np.int64(-1)
-
     # Optimized for C-contiguous array where the size of the sum axis is
     # >> preferred_work_group_size_multiple, and the size of the other axis (if any) is
     # is smaller or similar to preferred_work_group_size_multiple.
+    # ???: how does this strategy compares to having each thread reducing N contiguous
+    # items ?
     @dpex.kernel
     # fmt: off
     def partial_sum_reduction(
@@ -264,38 +265,38 @@ def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dt
         local_work_id = dpex.get_local_id(zero_idx)
         first_work_id = local_work_id == zero_idx
 
-        size = summands.shape[m_one_idx]
+        size = summands.shape[minus_one_idx]
 
-        local_data = dpex.local.array(local_data_size, dtype=dtype)
+        local_values = dpex.local.array(local_values_size, dtype=dtype)
 
-        first_value_idx = group_id * work_group_size * two_long
+        first_value_idx = group_id * work_group_size * two_as_a_long
         augend_idx = first_value_idx + local_work_id
         addend_idx = first_value_idx + work_group_size + local_work_id
 
         # Each work item reads two value in global memory and sum it into the local
         # memory
         if augend_idx >= size:
-            set_col_to_zero(local_data, local_work_id)
+            set_col_to_zero(local_values, local_work_id)
         elif addend_idx >= size:
-            copy_col(summands, augend_idx, local_data, local_work_id)
+            copy_col(summands, augend_idx, local_values, local_work_id)
         else:
-            coalesce_cols(summands, augend_idx, addend_idx, local_data, local_work_id)
+            add_cols(summands, augend_idx, addend_idx, local_values, local_work_id)
 
         dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
         current_n_work_items = work_group_size
         for i in range(local_n_iterations):
             # We discard half of the remaining active work items at each iteration
-            current_n_work_items = current_n_work_items // two_long
+            current_n_work_items = current_n_work_items // two_as_a_long
             if local_work_id < current_n_work_items:
-                coalesce_cols_inplace(local_data, local_work_id + current_n_work_items, local_work_id)
+                add_cols_inplace(local_values, local_work_id + current_n_work_items, local_work_id)
 
             dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 
-        # At this point local_data[0] + local_data[1] is equal to the sum of all
+        # At this point local_values[0] + local_values[1] is equal to the sum of all
         # elements in summands that have been covered by the work group, we write it
         # into global memory
         if first_work_id:
-            coalesce_first_cols(local_data, result, group_id)
+            add_first_cols(local_values, result, group_id)
 
     # As many partial reductions as necessary are chained until only one element
     # remains.
@@ -329,7 +330,7 @@ def make_argmin_reduction_1d_kernel(size, work_group_size, device, dtype):
     # Number of iteration in each execution of the kernel:
     local_n_iterations = np.int64(math.floor(math.log2(work_group_size)) - 1)
 
-    two_long = np.int64(2)
+    two_as_a_long = np.int64(2)
     one_idx = np.int64(1)
     inf = dtype(np.inf)
 
@@ -340,9 +341,9 @@ def make_argmin_reduction_1d_kernel(size, work_group_size, device, dtype):
     @dpex.kernel
     # fmt: off
     def partial_argmin_reduction(
-        data,               # IN        (size,)
+        values,             # IN        (size,)
         previous_result,    # IN        (current_size,)
-        result,             # OUT       (math.ceil(
+        argmin_indices,     # OUT       (math.ceil(
                             #               (current_size if current_size else size)
                             #                / (2 * work_group_size),)
                             #            ))
@@ -354,63 +355,63 @@ def make_argmin_reduction_1d_kernel(size, work_group_size, device, dtype):
 
         previous_result_size = previous_result.shape[zero_idx]
         has_previous_result = previous_result_size > one_idx
-        current_size = previous_result_size if has_previous_result else data.shape[zero_idx]
+        current_size = previous_result_size if has_previous_result else values.shape[zero_idx]
 
         local_argmin = dpex.local.array(work_group_size, dtype=np.int32)
-        local_data = dpex.local.array(work_group_size, dtype=dtype)
+        local_values = dpex.local.array(work_group_size, dtype=dtype)
 
-        first_value_idx = group_id * work_group_size * two_long
+        first_value_idx = group_id * work_group_size * two_as_a_long
         x_idx = first_value_idx + local_work_id
         y_idx = first_value_idx + work_group_size + local_work_id
 
         if x_idx >= current_size:
-            local_data[local_work_id] = inf
+            local_values[local_work_id] = inf
         else:
             if has_previous_result:
                 x_idx = previous_result[x_idx]
 
             if y_idx >= current_size:
                 local_argmin[local_work_id] = x_idx
-                local_data[local_work_id] = data[x_idx]
+                local_values[local_work_id] = values[x_idx]
 
             else:
                 if has_previous_result:
                     y_idx = previous_result[y_idx]
 
-                x_data = data[x_idx]
-                y_data = data[y_idx]
-                if x_data <= y_data:
+                x = values[x_idx]
+                y = values[y_idx]
+                if x < y or (x == y and x_idx < y_idx):
                     local_argmin[local_work_id] = x_idx
-                    local_data[local_work_id] = x_data
+                    local_values[local_work_id] = x 
                 else:
                     local_argmin[local_work_id] = y_idx
-                    local_data[local_work_id] = y_data
+                    local_values[local_work_id] = y
 
         dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
         current_n_work_items = work_group_size
         for i in range(local_n_iterations):
-            current_n_work_items = current_n_work_items // two_long
+            current_n_work_items = current_n_work_items // two_as_a_long
             if local_work_id < current_n_work_items:
                 local_x_idx = local_work_id
                 local_y_idx = local_work_id + current_n_work_items
 
-                x_data = local_data[local_x_idx]
-                y_data = local_data[local_y_idx]
+                x= local_values[local_x_idx]
+                y= local_values[local_y_idx]
 
-                if x_data > y_data:
-                    local_data[local_x_idx] = y_data
+                if x> y:
+                    local_values[local_x_idx] = y
                     local_argmin[local_x_idx] = local_argmin[local_y_idx]
 
             dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 
         if first_work_id:
-            if local_data[zero_idx] <= local_data[one_idx]:
-                result[group_id] = local_argmin[zero_idx]
+            if local_values[zero_idx] <= local_values[one_idx]:
+                argmin_indices[group_id] = local_argmin[zero_idx]
             else:
-                result[group_id] = local_argmin[one_idx]
+                argmin_indices[group_id] = local_argmin[one_idx]
 
     # As many partial reductions as necessary are chained until only one element
-    # remains.
+    # remains.argmin_indices
     kernels_and_empty_tensors_tuples = []
     n_groups = size
     previous_result = dpt.empty((1,), dtype=np.int32, device=device)
@@ -422,9 +423,9 @@ def make_argmin_reduction_1d_kernel(size, work_group_size, device, dtype):
         kernels_and_empty_tensors_tuples.append((kernel, previous_result, result))
         previous_result = result
 
-    def argmin_reduction(data):
+    def argmin_reduction(values):
         for kernel, previous_result, result in kernels_and_empty_tensors_tuples:
-            kernel(data, previous_result, result)
+            kernel(values, previous_result, result)
         return result
 
     return argmin_reduction

--- a/sklearn_numba_dpex/common/kernels.py
+++ b/sklearn_numba_dpex/common/kernels.py
@@ -130,7 +130,7 @@ def make_half_l2_norm_2d_axis0_kernel(size0, size1, work_group_size, dtype):
 
 
 @lru_cache
-def make_sum_reduction_1d_kernel(size, work_group_size, device, dtype):
+def make_sum_reduction_2d_axis1_kernel(size0, size1, work_group_size, device, dtype):
     """numba_dpex does not provide tools such as `cuda.reduce` so we implement from
     scratch a reduction strategy. The strategy relies on the commutativity of the
     operation used for the reduction, thus allowing to reduce the input in any order.
@@ -148,6 +148,16 @@ def make_sum_reduction_1d_kernel(size, work_group_size, device, dtype):
     remains in global memory.
 
     NB: work_group_size is assumed to be a power of 2.
+
+    NB: if size1 is None then the kernel expects 1d tensor inputs. If size1 is not None
+    then the expected shape of input tensors is (size0, size1), and the reduction
+    operation is equivalent to input.sum(axis=1). In this case, the kernel is a good
+    choice if size1 >> preferred_work_group_size_multiple, and if size0 ranges in the
+    same order of magnitude than preferred_work_group_size_multiple. If not, other
+    reduction implementations might give better performances.
+
+    ???: how does this strategy compares to having each thread reducing N contiguous
+    items ?
     """
     # Number of iteration in each execution of the kernel:
     local_n_iterations = np.int64(math.floor(math.log2(work_group_size)) - 1)
@@ -156,11 +166,97 @@ def make_sum_reduction_1d_kernel(size, work_group_size, device, dtype):
     two_long = np.int64(2)
     one_idx = np.int64(1)
 
+    is_1d = size1 is None
+    if is_1d:
+        sum_axis_size = size0
+        n_rows = np.int64(1)
+        local_data_size = work_group_size
+
+        @dpex.func
+        def set_col_to_zero(array, i):
+            array[i] = zero
+
+        @dpex.func
+        def copy_col(from_array, from_col, to_array, to_col):
+            to_array[to_col] = from_array[from_col]
+
+        @dpex.func
+        def coalesce_cols(
+            from_array,
+            left_from_col,
+            right_from_col,
+            to_array,
+            to_col,
+        ):
+            to_array[to_col] = from_array[left_from_col] + from_array[right_from_col]
+
+        @dpex.func
+        def coalesce_cols_inplace(
+            array,
+            from_col,
+            to_col,
+        ):
+            array[to_col] += array[from_col]
+
+        @dpex.func
+        def coalesce_first_cols(from_array, to_array, to_col):
+            to_array[to_col] = from_array[zero_idx] + from_array[one_idx]
+
+    else:
+        sum_axis_size = size1
+        n_rows = size0
+        local_data_size = (size0, work_group_size)
+
+        @dpex.func
+        def set_col_to_zero(array, i):
+            for row in range(n_rows):
+                array[row, i] = zero
+
+        @dpex.func
+        def copy_col(from_array, from_col, to_array, to_col):
+            for row in range(n_rows):
+                to_array[row, to_col] = from_array[row, from_col]
+
+        @dpex.func
+        def coalesce_cols(
+            from_array,
+            left_from_col,
+            right_from_col,
+            to_array,
+            to_col,
+        ):
+            for row in range(n_rows):
+                to_array[row, to_col] = (
+                    from_array[row, left_from_col] + from_array[row, right_from_col]
+                )
+
+        @dpex.func
+        def coalesce_cols_inplace(
+            array,
+            from_col,
+            to_col,
+        ):
+            for row in range(n_rows):
+                array[row, to_col] += array[row, from_col]
+
+        @dpex.func
+        def coalesce_first_cols(from_array, to_array, to_col):
+            for row in range(n_rows):
+                to_array[row, to_col] = (
+                    from_array[row, zero_idx] + from_array[row, one_idx]
+                )
+
+    two_long = np.int64(2)
+    m_one_idx = np.int64(-1)
+
+    # Optimized for C-contiguous array where the size of the sum axis is
+    # >> preferred_work_group_size_multiple, and the size of the other axis (if any) is
+    # is smaller or similar to preferred_work_group_size_multiple.
     @dpex.kernel
     # fmt: off
     def partial_sum_reduction(
-        summands,    # IN        (size,)
-        result,      # OUT       (math.ceil(size / (2 * work_group_size),)
+        summands,    # IN        (n_rows, sum_axis_size)
+        result,      # OUT       (n_rows, math.ceil(size / (2 * work_group_size),)
     ):
     # fmt: on
         # NB: This kernel only perform a partial reduction
@@ -168,9 +264,9 @@ def make_sum_reduction_1d_kernel(size, work_group_size, device, dtype):
         local_work_id = dpex.get_local_id(zero_idx)
         first_work_id = local_work_id == zero_idx
 
-        size = summands.shape[zero_idx]
+        size = summands.shape[m_one_idx]
 
-        local_data = dpex.local.array(work_group_size, dtype=dtype)
+        local_data = dpex.local.array(local_data_size, dtype=dtype)
 
         first_value_idx = group_id * work_group_size * two_long
         augend_idx = first_value_idx + local_work_id
@@ -179,11 +275,11 @@ def make_sum_reduction_1d_kernel(size, work_group_size, device, dtype):
         # Each work item reads two value in global memory and sum it into the local
         # memory
         if augend_idx >= size:
-            local_data[local_work_id] = zero
+            set_col_to_zero(local_data, local_work_id)
         elif addend_idx >= size:
-            local_data[local_work_id] = summands[augend_idx]
+            copy_col(summands, augend_idx, local_data, local_work_id)
         else:
-            local_data[local_work_id] = summands[augend_idx] + summands[addend_idx]
+            coalesce_cols(summands, augend_idx, addend_idx, local_data, local_work_id)
 
         dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
         current_n_work_items = work_group_size
@@ -191,22 +287,20 @@ def make_sum_reduction_1d_kernel(size, work_group_size, device, dtype):
             # We discard half of the remaining active work items at each iteration
             current_n_work_items = current_n_work_items // two_long
             if local_work_id < current_n_work_items:
-                local_data[local_work_id] += local_data[
-                    local_work_id + current_n_work_items
-                ]
+                coalesce_cols_inplace(local_data, local_work_id + current_n_work_items, local_work_id)
 
             dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 
-        # At this point local_data[0] = local_data[1]  is equal to the sum of all
+        # At this point local_data[0] + local_data[1] is equal to the sum of all
         # elements in summands that have been covered by the work group, we write it
         # into global memory
         if first_work_id:
-            result[group_id] = local_data[zero_idx] + local_data[one_idx]
+            coalesce_first_cols(local_data, result, group_id)
 
     # As many partial reductions as necessary are chained until only one element
     # remains.
     kernels_and_empty_tensors_pairs = []
-    n_groups = size
+    n_groups = sum_axis_size
     # TODO: at some point, the cost of scheduling the kernel is more than the cost of
     # running the reduction iteration. At this point the loop should stop and then a
     # single work item should iterates one time on the remaining values to finish the
@@ -215,13 +309,122 @@ def make_sum_reduction_1d_kernel(size, work_group_size, device, dtype):
         n_groups = math.ceil(n_groups / (2 * work_group_size))
         global_size = n_groups * work_group_size
         kernel = partial_sum_reduction[global_size, work_group_size]
-        result = dpt.empty(n_groups, dtype=dtype, device=device)
+        result_shape = n_groups if is_1d else (n_rows, n_groups)
+        result = dpt.empty(result_shape, dtype=dtype, device=device)
         kernels_and_empty_tensors_pairs.append((kernel, result))
 
     def sum_reduction(summands):
+        # TODO: manually dispatch the kernels with a SyclQueue
         for kernel, result in kernels_and_empty_tensors_pairs:
             kernel(summands, result)
             summands = result
         return result
 
     return sum_reduction
+
+
+@lru_cache
+def make_argmin_reduction_1d_kernel(size, work_group_size, device, dtype):
+    """Implement 1d argmin with the same strategy than for make_sum_reduction_2d_axis1_kernel."""
+    # Number of iteration in each execution of the kernel:
+    local_n_iterations = np.int64(math.floor(math.log2(work_group_size)) - 1)
+
+    two_long = np.int64(2)
+    one_idx = np.int64(1)
+    inf = dtype(np.inf)
+
+    # TODO: the first call of partial_argmin_reduction in the final loop should be
+    # written with only two arguments since "previous_result" does not exist yet.
+    # It seems it's not possible to get a good factoring of the code to avoid copying
+    # most of the code for this with @dpex.kernel, for now we resort to branching.
+    @dpex.kernel
+    # fmt: off
+    def partial_argmin_reduction(
+        data,               # IN        (size,)
+        previous_result,    # IN        (current_size,)
+        result,             # OUT       (math.ceil(
+                            #               (current_size if current_size else size)
+                            #                / (2 * work_group_size),)
+                            #            ))
+    ):
+    # fmt: on
+        group_id = dpex.get_group_id(zero_idx)
+        local_work_id = dpex.get_local_id(zero_idx)
+        first_work_id = local_work_id == zero_idx
+
+        previous_result_size = previous_result.shape[zero_idx]
+        has_previous_result = previous_result_size > one_idx
+        current_size = previous_result_size if has_previous_result else data.shape[zero_idx]
+
+        local_argmin = dpex.local.array(work_group_size, dtype=np.int32)
+        local_data = dpex.local.array(work_group_size, dtype=dtype)
+
+        first_value_idx = group_id * work_group_size * two_long
+        x_idx = first_value_idx + local_work_id
+        y_idx = first_value_idx + work_group_size + local_work_id
+
+        if x_idx >= current_size:
+            local_data[local_work_id] = inf
+        else:
+            if has_previous_result:
+                x_idx = previous_result[x_idx]
+
+            if y_idx >= current_size:
+                local_argmin[local_work_id] = x_idx
+                local_data[local_work_id] = data[x_idx]
+
+            else:
+                if has_previous_result:
+                    y_idx = previous_result[y_idx]
+
+                x_data = data[x_idx]
+                y_data = data[y_idx]
+                if x_data <= y_data:
+                    local_argmin[local_work_id] = x_idx
+                    local_data[local_work_id] = x_data
+                else:
+                    local_argmin[local_work_id] = y_idx
+                    local_data[local_work_id] = y_data
+
+        dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
+        current_n_work_items = work_group_size
+        for i in range(local_n_iterations):
+            current_n_work_items = current_n_work_items // two_long
+            if local_work_id < current_n_work_items:
+                local_x_idx = local_work_id
+                local_y_idx = local_work_id + current_n_work_items
+
+                x_data = local_data[local_x_idx]
+                y_data = local_data[local_y_idx]
+
+                if x_data > y_data:
+                    local_data[local_x_idx] = y_data
+                    local_argmin[local_x_idx] = local_argmin[local_y_idx]
+
+            dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
+
+        if first_work_id:
+            if local_data[zero_idx] <= local_data[one_idx]:
+                result[group_id] = local_argmin[zero_idx]
+            else:
+                result[group_id] = local_argmin[one_idx]
+
+    # As many partial reductions as necessary are chained until only one element
+    # remains.
+    kernels_and_empty_tensors_tuples = []
+    n_groups = size
+    previous_result = dpt.empty((1,), dtype=np.int32, device=device)
+    while n_groups > 1:
+        n_groups = math.ceil(n_groups / (2 * work_group_size))
+        global_size = n_groups * work_group_size
+        kernel = partial_argmin_reduction[global_size, work_group_size]
+        result = dpt.empty(n_groups, dtype=np.int32, device=device)
+        kernels_and_empty_tensors_tuples.append((kernel, previous_result, result))
+        previous_result = result
+
+    def argmin_reduction(data):
+        for kernel, previous_result, result in kernels_and_empty_tensors_tuples:
+            kernel(data, previous_result, result)
+        return result
+
+    return argmin_reduction

--- a/sklearn_numba_dpex/common/tests/test_kernels.py
+++ b/sklearn_numba_dpex/common/tests/test_kernels.py
@@ -5,6 +5,8 @@ import dpctl.tensor as dpt
 
 import numpy as np
 
+from sklearn.utils._testing import assert_allclose
+
 from sklearn_numba_dpex.common.kernels import (
     make_sum_reduction_2d_axis1_kernel,
     make_argmin_reduction_1d_kernel,
@@ -14,20 +16,19 @@ from sklearn_numba_dpex.testing.config import float_dtype_params
 
 @pytest.mark.parametrize("dtype", float_dtype_params)
 def test_sum_reduction_2d(dtype):
-    n_reductions = 3
-    n_items = 4
+    array_in = dpt.reshape(dpt.arange(12, dtype=dtype), (3, 4))
+
     device = dpctl.SyclDevice()
     work_group_size = device.max_work_group_size
 
     sum_reduction_2d_kernel = make_sum_reduction_2d_axis1_kernel(
-        size0=n_reductions,
-        size1=n_items,
+        size0=len(array_in),
+        size1=array_in.shape[1],
         work_group_size=work_group_size,
         device=device,
         dtype=dtype,
     )
 
-    array_in = dpt.reshape(dpt.arange(12, dtype=dtype), (3, 4))
     # [[0.0, 1.0, 2.0, 3.0],
     #  [4.0, 5.0, 6.0, 7.0],
     #  [8.0, 9.0, 10.0, 11.0]]
@@ -36,57 +37,59 @@ def test_sum_reduction_2d(dtype):
 
     actual_result = dpt.asnumpy(dpt.squeeze(sum_reduction_2d_kernel(array_in)))
 
-    np.testing.assert_array_equal(expected_result, actual_result)
+    assert_allclose(expected_result, actual_result)
 
 
 @pytest.mark.parametrize("dtype", float_dtype_params)
 def test_sum_reduction_1d(dtype):
-    n_items = 4
     device = dpctl.SyclDevice()
     work_group_size = device.max_work_group_size
 
+    array_in = dpt.arange(4, dtype=dtype)
+
     sum_reduction_1d_kernel = make_sum_reduction_2d_axis1_kernel(
-        size0=n_items,
+        size0=len(array_in),
         size1=None,
         work_group_size=work_group_size,
         device=device,
         dtype=dtype,
     )
 
-    array_in = dpt.arange(4, dtype=dtype)
     # [0.0, 1.0, 2.0, 3.0]
 
     expected_result = 6
 
     actual_result = int(dpt.asnumpy(sum_reduction_1d_kernel(array_in))[0])
 
-    assert actual_result == expected_result
+    assert actual_result == pytest.approx(expected_result)
 
 
 @pytest.mark.parametrize("dtype", float_dtype_params)
 def test_argmin_reduction_1d(dtype):
-    n_items = 4
+    array_in = dpt.asarray([3.0, 1.0, 0.0, 2.0], dtype=dtype)
     device = dpctl.SyclDevice()
     work_group_size = device.max_work_group_size
 
     argmin_reduction_1d_kernel = make_argmin_reduction_1d_kernel(
-        size=n_items,
+        size=len(array_in),
         work_group_size=work_group_size,
         device=device,
         dtype=dtype,
     )
 
-    array_in = dpt.asarray([3.0, 1.0, 0.0, 2.0], dtype=dtype)
     expected_result = 2
-    actual_result = int(dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0])
+    actual_result = dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0]
+    assert actual_result.dtype == np.int32
     assert actual_result == expected_result
 
-    array_in = dpt.asarray([0.0, 1.0, 3.0, 2.0], dtype=dtype)
+    array_in[:] = [0.0, 1.0, 3.0, 2.0]
     expected_result = 0
-    actual_result = int(dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0])
+    actual_result = dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0]
+    assert actual_result.dtype == np.int32
     assert actual_result == expected_result
 
-    array_in = dpt.asarray([3.0, 1.0, 2.0, 0.0], dtype=dtype)
+    array_in[:] = [3.0, 1.0, 2.0, 0.0]
     expected_result = 3
-    actual_result = int(dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0])
+    actual_result = dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0]
+    assert actual_result.dtype == np.int32
     assert actual_result == expected_result

--- a/sklearn_numba_dpex/common/tests/test_kernels.py
+++ b/sklearn_numba_dpex/common/tests/test_kernels.py
@@ -14,12 +14,33 @@ from sklearn_numba_dpex.common.kernels import (
 from sklearn_numba_dpex.testing.config import float_dtype_params
 
 
+@pytest.mark.parametrize("work_group_size", [2, 4, 8, "max"])
+@pytest.mark.parametrize(
+    ("array_in, expected_result"),
+    [
+        (
+            # [[0.0, 1.0, 2.0, 3.0],
+            #  [4.0, 5.0, 6.0, 7.0],
+            #  [8.0, 9.0, 10.0, 11.0]]
+            dpt.reshape(dpt.arange(12), (3, 4)),
+            np.array([6.0, 22.0, 38.0]),
+        ),
+        (
+            # [[0.0, 1.0, 2.0, 3.0, 4.0],
+            #  [5.0, 6.0, 7.0, 8.0, 9.0],
+            #  [10.0, 11.0, 12.0, 13.0, 14.0]]
+            dpt.reshape(dpt.arange(15), (3, 5)),
+            np.array([10.0, 35.0, 60.0]),
+        ),
+    ],
+)
 @pytest.mark.parametrize("dtype", float_dtype_params)
-def test_sum_reduction_2d(dtype):
-    array_in = dpt.reshape(dpt.arange(12, dtype=dtype), (3, 4))
+def test_sum_reduction_2d(array_in, expected_result, dtype, work_group_size):
+    array_in = dpt.astype(array_in, dtype)
 
     device = dpctl.SyclDevice()
-    work_group_size = device.max_work_group_size
+    if work_group_size == "max":
+        work_group_size = device.max_work_group_size
 
     sum_reduction_2d_kernel = make_sum_reduction_2d_axis1_kernel(
         size0=len(array_in),
@@ -29,23 +50,20 @@ def test_sum_reduction_2d(dtype):
         dtype=dtype,
     )
 
-    # [[0.0, 1.0, 2.0, 3.0],
-    #  [4.0, 5.0, 6.0, 7.0],
-    #  [8.0, 9.0, 10.0, 11.0]]
-
-    expected_result = np.array([6.0, 22.0, 38.0], dtype=dtype)
-
     actual_result = dpt.asnumpy(dpt.squeeze(sum_reduction_2d_kernel(array_in)))
 
     assert_allclose(expected_result, actual_result)
 
 
+@pytest.mark.parametrize("work_group_size", [2, 4, 8, "max"])
+@pytest.mark.parametrize("length, expected_result", [(4, 6), (5, 10)])
 @pytest.mark.parametrize("dtype", float_dtype_params)
-def test_sum_reduction_1d(dtype):
+def test_sum_reduction_1d(length, expected_result, dtype, work_group_size):
     device = dpctl.SyclDevice()
-    work_group_size = device.max_work_group_size
+    if work_group_size == "max":
+        work_group_size = device.max_work_group_size
 
-    array_in = dpt.arange(4, dtype=dtype)
+    array_in = dpt.arange(length, dtype=dtype)
 
     sum_reduction_1d_kernel = make_sum_reduction_2d_axis1_kernel(
         size0=len(array_in),
@@ -55,20 +73,26 @@ def test_sum_reduction_1d(dtype):
         dtype=dtype,
     )
 
-    # [0.0, 1.0, 2.0, 3.0]
-
-    expected_result = 6
-
-    actual_result = int(dpt.asnumpy(sum_reduction_1d_kernel(array_in))[0])
+    actual_result = dpt.asnumpy(sum_reduction_1d_kernel(array_in))[0]
 
     assert actual_result == pytest.approx(expected_result)
 
 
+@pytest.mark.parametrize("work_group_size", [2, 4, 8, "max"])
+@pytest.mark.parametrize(
+    ("array_in, expected_result"),
+    [
+        (dpt.asarray([3.0, 1.0, 0.0, 2.0]), 2),
+        (dpt.asarray([0.0, 1.0, 3.0, 2.0]), 0),
+        (dpt.asarray([3.0, 1.0, 2.0, -1.0, -2.0]), 4),
+    ],
+)
 @pytest.mark.parametrize("dtype", float_dtype_params)
-def test_argmin_reduction_1d(dtype):
-    array_in = dpt.asarray([3.0, 1.0, 0.0, 2.0], dtype=dtype)
+def test_argmin_reduction_1d(array_in, expected_result, dtype, work_group_size):
+    array_in = dpt.astype(array_in, dtype)
     device = dpctl.SyclDevice()
-    work_group_size = device.max_work_group_size
+    if work_group_size == "max":
+        work_group_size = device.max_work_group_size
 
     argmin_reduction_1d_kernel = make_argmin_reduction_1d_kernel(
         size=len(array_in),
@@ -77,19 +101,6 @@ def test_argmin_reduction_1d(dtype):
         dtype=dtype,
     )
 
-    expected_result = 2
-    actual_result = dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0]
-    assert actual_result.dtype == np.int32
-    assert actual_result == expected_result
-
-    array_in[:] = [0.0, 1.0, 3.0, 2.0]
-    expected_result = 0
-    actual_result = dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0]
-    assert actual_result.dtype == np.int32
-    assert actual_result == expected_result
-
-    array_in[:] = [3.0, 1.0, 2.0, 0.0]
-    expected_result = 3
     actual_result = dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0]
     assert actual_result.dtype == np.int32
     assert actual_result == expected_result

--- a/sklearn_numba_dpex/common/tests/test_kernels.py
+++ b/sklearn_numba_dpex/common/tests/test_kernels.py
@@ -1,0 +1,92 @@
+import pytest
+
+import dpctl
+import dpctl.tensor as dpt
+
+import numpy as np
+
+from sklearn_numba_dpex.common.kernels import (
+    make_sum_reduction_2d_axis1_kernel,
+    make_argmin_reduction_1d_kernel,
+)
+from sklearn_numba_dpex.testing.config import float_dtype_params
+
+
+@pytest.mark.parametrize("dtype", float_dtype_params)
+def test_sum_reduction_2d(dtype):
+    n_reductions = 3
+    n_items = 4
+    device = dpctl.SyclDevice()
+    work_group_size = device.max_work_group_size
+
+    sum_reduction_2d_kernel = make_sum_reduction_2d_axis1_kernel(
+        size0=n_reductions,
+        size1=n_items,
+        work_group_size=work_group_size,
+        device=device,
+        dtype=dtype,
+    )
+
+    array_in = dpt.reshape(dpt.arange(12, dtype=dtype), (3, 4))
+    # [[0.0, 1.0, 2.0, 3.0],
+    #  [4.0, 5.0, 6.0, 7.0],
+    #  [8.0, 9.0, 10.0, 11.0]]
+
+    expected_result = np.array([6.0, 22.0, 38.0], dtype=dtype)
+
+    actual_result = dpt.asnumpy(dpt.squeeze(sum_reduction_2d_kernel(array_in)))
+
+    np.testing.assert_array_equal(expected_result, actual_result)
+
+
+@pytest.mark.parametrize("dtype", float_dtype_params)
+def test_sum_reduction_1d(dtype):
+    n_items = 4
+    device = dpctl.SyclDevice()
+    work_group_size = device.max_work_group_size
+
+    sum_reduction_1d_kernel = make_sum_reduction_2d_axis1_kernel(
+        size0=n_items,
+        size1=None,
+        work_group_size=work_group_size,
+        device=device,
+        dtype=dtype,
+    )
+
+    array_in = dpt.arange(4, dtype=dtype)
+    # [0.0, 1.0, 2.0, 3.0]
+
+    expected_result = 6
+
+    actual_result = int(dpt.asnumpy(sum_reduction_1d_kernel(array_in))[0])
+
+    assert actual_result == expected_result
+
+
+@pytest.mark.parametrize("dtype", float_dtype_params)
+def test_argmin_reduction_1d(dtype):
+    n_items = 4
+    device = dpctl.SyclDevice()
+    work_group_size = device.max_work_group_size
+
+    argmin_reduction_1d_kernel = make_argmin_reduction_1d_kernel(
+        size=n_items,
+        work_group_size=work_group_size,
+        device=device,
+        dtype=dtype,
+    )
+
+    array_in = dpt.asarray([3.0, 1.0, 0.0, 2.0], dtype=dtype)
+    expected_result = 2
+    actual_result = int(dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0])
+    assert actual_result == expected_result
+
+    array_in = dpt.asarray([0.0, 1.0, 3.0, 2.0], dtype=dtype)
+    expected_result = 0
+    actual_result = int(dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0])
+    assert actual_result == expected_result
+
+    array_in = dpt.asarray([3.0, 1.0, 2.0, 0.0], dtype=dtype)
+    expected_result = 3
+    actual_result = int(dpt.asnumpy(argmin_reduction_1d_kernel(array_in))[0])
+    assert actual_result == expected_result

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -15,7 +15,7 @@ from sklearn_numba_dpex.common.kernels import (
     make_initialize_to_zeros_3d_kernel,
     make_broadcast_division_1d_2d_kernel,
     make_half_l2_norm_2d_axis0_kernel,
-    make_sum_reduction_1d_kernel,
+    make_sum_reduction_2d_axis1_kernel,
 )
 
 from sklearn_numba_dpex.kmeans.kernels import (
@@ -315,15 +315,17 @@ class KMeansDriver:
             dtype=compute_dtype,
         )
 
-        reduce_inertia_kernel = make_sum_reduction_1d_kernel(
-            size=n_samples,
+        reduce_inertia_kernel = make_sum_reduction_2d_axis1_kernel(
+            size0=n_samples,
+            size1=None,
             work_group_size=work_group_size,
             device=self.device,
             dtype=compute_dtype,
         )
 
-        reduce_centroid_shifts_kernel = make_sum_reduction_1d_kernel(
-            size=n_clusters,
+        reduce_centroid_shifts_kernel = make_sum_reduction_2d_axis1_kernel(
+            size0=n_clusters,
+            size1=None,
             work_group_size=work_group_size,
             device=self.device,
             dtype=compute_dtype,
@@ -713,8 +715,9 @@ class KMeansDriver:
             compute_dtype,
         )
 
-        reduce_inertia_kernel = make_sum_reduction_1d_kernel(
-            size=n_samples,
+        reduce_inertia_kernel = make_sum_reduction_2d_axis1_kernel(
+            size0=n_samples,
+            size1=None,
             work_group_size=work_group_size,
             device=self.device,
             dtype=compute_dtype,

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -317,7 +317,7 @@ class KMeansDriver:
 
         reduce_inertia_kernel = make_sum_reduction_2d_axis1_kernel(
             size0=n_samples,
-            size1=None,
+            size1=None,  # 1d reduction
             work_group_size=work_group_size,
             device=self.device,
             dtype=compute_dtype,
@@ -325,7 +325,7 @@ class KMeansDriver:
 
         reduce_centroid_shifts_kernel = make_sum_reduction_2d_axis1_kernel(
             size0=n_clusters,
-            size1=None,
+            size1=None,  # 1d reduction
             work_group_size=work_group_size,
             device=self.device,
             dtype=compute_dtype,
@@ -717,7 +717,7 @@ class KMeansDriver:
 
         reduce_inertia_kernel = make_sum_reduction_2d_axis1_kernel(
             size0=n_samples,
-            size1=None,
+            size1=None,  # 1d reduction
             work_group_size=work_group_size,
             device=self.device,
             dtype=compute_dtype,

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -1,4 +1,3 @@
-import math
 import warnings
 from functools import lru_cache
 
@@ -30,10 +29,7 @@ from sklearn_numba_dpex.kmeans.kernels import (
 )
 
 
-def _check_power_of_2(e):
-    if e != 2 ** (math.log2(e)):
-        raise ValueError(f"Expected a power of 2, got {e}")
-    return e
+from sklearn_numba_dpex.common._utils import check_power_of_2
 
 
 class _IgnoreSampleWeight:
@@ -136,7 +132,7 @@ class KMeansDriver:
             global_mem_cache_size or device_params.global_mem_cache_size
         )
 
-        self.preferred_work_group_size_multiple = _check_power_of_2(
+        self.preferred_work_group_size_multiple = check_power_of_2(
             preferred_work_group_size_multiple
             or device_params.preferred_work_group_size_multiple
         )
@@ -145,15 +141,15 @@ class KMeansDriver:
         # this default.
         # TODO: when it's available in dpctl, use the `max_group_size` attribute
         # exposed by the kernel instead ?
-        self.work_group_size_multiplier = _check_power_of_2(
+        self.work_group_size_multiplier = check_power_of_2(
             work_group_size_multiplier or 2
         )
 
-        self.centroids_window_width_multiplier = _check_power_of_2(
+        self.centroids_window_width_multiplier = check_power_of_2(
             centroids_window_width_multiplier or 1
         )
 
-        self.centroids_window_height = _check_power_of_2(centroids_window_height or 16)
+        self.centroids_window_height = check_power_of_2(centroids_window_height or 16)
 
         self.centroids_private_copies_max_cache_occupancy = (
             centroids_private_copies_max_cache_occupancy or 0.7


### PR DESCRIPTION
Two things in this PR:

- [x] extend the sum reduction kernel for 1d arrays to 2d arrays when reducing over axis 1
- [x] add a similar argmin kernel

Not sure what is better, using those kernels or using `dpnp` functions.

Pros for using those kernels:
- limit the dependency to `dpnp` (which can especially be a good things if `numba_dpex` get interoperability to nvidia/amd gpus before `dpnp` does)
- more confidence regarding the strategy for dispatching to thread that fit more GPU devices, it's not clear at what point `dpnp` can run well on gpus
- fun

Cons for using those kernels:
- it's verbose, and if we want to optimize other usecases (depending if axis0 is "big enough", or else which is bigger from axis 0 or axis 1,...) it would require yet other kernels.
- it does not sound like it's a good thing to jit those simple operations, the added jit time might get annoying
- at some point, it can be assumed that a reliable tensor library (probably `dpnp` ?) will be available and the kernels will be obsolete anyway.
- even if the implementation fits the gpu model, I think the performance is not that great, it might become competitive if there's a public api in `numba_dpex` to use async dispatching like described in https://github.com/IntelPython/numba-dpex/issues/769 .
- in fact, the performance does not even really matter because until now I don't think it contributes much to total execution time anyway.

Those pro / cons can also be weighted for all other kernels in this file, implementations for most of those are already available in dpnp.