### PR TITLE
Refacto: get data conversion steps more visible

### DIFF
--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -6,7 +6,7 @@ import numpy as np
 import dpctl.tensor as dpt
 import dpctl
 import dpnp
-from sklearn.exceptions import NotSupportedByEngineError, DataConversionWarning
+from sklearn.exceptions import DataConversionWarning
 
 from sklearn_numba_dpex.device import DeviceParams
 
@@ -145,8 +145,10 @@ class KMeansDriver:
         # this default.
         # TODO: when it's available in dpctl, use the `max_group_size` attribute
         # exposed by the kernel instead ?
-        self.work_group_size_multiplier = _check_power_of_2(
-            work_group_size_multiplier or 2
+        work_group_size_multiplier = _check_power_of_2(work_group_size_multiplier or 2)
+
+        self.work_group_size = (
+            work_group_size_multiplier * self.preferred_work_group_size_multiple
         )
 
         self.centroids_window_width_multiplier = _check_power_of_2(
@@ -166,19 +168,6 @@ class KMeansDriver:
 
         self.has_aspect_fp64 = device_params.has_aspect_fp64
 
-        self.dtype = dtype
-        if dtype is not None:
-            dtype = np.dtype(dtype).type
-            if (dtype != np.float32) and (dtype != np.float64):
-                raise ValueError(f"Valid types are float64, float32, but got f{dtype}")
-            self.dtype = dtype
-            if (self.dtype == np.float64) and not self.has_aspect_fp64:
-                raise NotSupportedByEngineError(
-                    f"Computations with precision f{self.dtype} has been explicitly "
-                    f"requested to the KMeans driver but the device {dpctl_device.name} does not "
-                    f"support it."
-                )
-
     def lloyd(
         self,
         X,
@@ -191,16 +180,23 @@ class KMeansDriver:
         """This call is expected to accept the same inputs than sklearn's private
         _kmeans_single_lloyd and produce the same outputs.
         """
-        (
-            assignments_idx,
-            inertia,
-            best_centroids,
-            n_iteration,
-            output_dtype,
-        ) = self._lloyd(
+        (X, sample_weight, cluster_centers, output_dtype) = self._check_inputs(
+            X, sample_weight, centers_init
+        )
+
+        use_uniform_weights = (sample_weight == sample_weight[0]).all()
+
+        X_t, sample_weight, centroids_t = self._load_transposed_data_to_device(
             X,
             sample_weight,
-            centers_init,
+            cluster_centers,
+        )
+
+        (assignments_idx, inertia, best_centroids, n_iteration,) = self._lloyd(
+            X_t,
+            sample_weight,
+            centroids_t,
+            use_uniform_weights,
             max_iter,
             verbose,
             tol,
@@ -222,27 +218,19 @@ class KMeansDriver:
 
     def _lloyd(
         self,
-        X,
+        X_t,
         sample_weight,
-        centers_init,
+        centroids_t,
+        use_uniform_weights,
         max_iter=300,
         verbose=False,
         tol=1e-4,
     ):
-
-        (
-            X,
-            sample_weight,
-            cluster_centers,
-            compute_dtype,
-            output_dtype,
-            work_group_size,
-        ) = self._check_inputs(X, sample_weight, centers_init)
-        n_samples, n_features = X.shape
-        n_clusters = cluster_centers.shape[0]
+        n_features, n_samples = X_t.shape
+        n_clusters = centroids_t.shape[1]
+        compute_dtype = X_t.dtype.type
 
         verbose = bool(verbose)
-        use_uniform_weights = (sample_weight == sample_weight[0]).all()
 
         # Create a set of kernels
         (
@@ -258,7 +246,7 @@ class KMeansDriver:
             centroids_window_width_multiplier=self.centroids_window_width_multiplier,
             centroids_window_height=self.centroids_window_height,
             centroids_private_copies_max_cache_occupancy=self.centroids_private_copies_max_cache_occupancy,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
 
@@ -269,21 +257,21 @@ class KMeansDriver:
             preferred_work_group_size_multiple=self.preferred_work_group_size_multiple,
             centroids_window_width_multiplier=self.centroids_window_width_multiplier,
             centroids_window_height=self.centroids_window_height,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
 
         compute_inertia_kernel = make_compute_inertia_kernel(
             n_samples,
             n_features,
-            work_group_size,
+            self.work_group_size,
             compute_dtype,
         )
 
         reset_cluster_sizes_private_copies_kernel = make_initialize_to_zeros_2d_kernel(
             size0=n_centroids_private_copies,
             size1=n_clusters,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
 
@@ -291,40 +279,40 @@ class KMeansDriver:
             size0=n_centroids_private_copies,
             size1=n_features,
             size2=n_clusters,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
 
         broadcast_division_kernel = make_broadcast_division_1d_2d_kernel(
             size0=n_features,
             size1=n_clusters,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
         )
 
         compute_centroid_shifts_kernel = make_centroid_shifts_kernel(
             n_clusters=n_clusters,
             n_features=n_features,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
 
         half_l2_norm_kernel = make_half_l2_norm_2d_axis0_kernel(
             size0=n_features,
             size1=n_clusters,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
 
         reduce_inertia_kernel = make_sum_reduction_1d_kernel(
             size=n_samples,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             device=self.device,
             dtype=compute_dtype,
         )
 
         reduce_centroid_shifts_kernel = make_sum_reduction_1d_kernel(
             size=n_clusters,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             device=self.device,
             dtype=compute_dtype,
         )
@@ -333,14 +321,8 @@ class KMeansDriver:
             n_centroids_private_copies=n_centroids_private_copies,
             n_features=n_features,
             n_clusters=n_clusters,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
-        )
-
-        X_t, sample_weight, centroids_t = self._load_transposed_data_to_device(
-            X,
-            sample_weight,
-            cluster_centers,
         )
 
         # Allocate the necessary memory in the device global memory
@@ -460,8 +442,6 @@ class KMeansDriver:
                     empty_clusters_list,
                     sq_dist_to_nearest_centroid,
                     per_sample_inertia,
-                    work_group_size,
-                    compute_dtype,
                 )
 
             broadcast_division_kernel(new_centroids_t, cluster_sizes)
@@ -546,7 +526,6 @@ class KMeansDriver:
             inertia,
             centroids_t.T,
             n_iteration,
-            output_dtype,
         )
 
     def _relocate_empty_clusters(
@@ -560,14 +539,13 @@ class KMeansDriver:
         empty_clusters_list,
         sq_dist_to_nearest_centroid,
         per_sample_inertia,
-        work_group_size,
-        compute_dtype,
     ):
+        compute_dtype = X_t.dtype.type
         n_features, n_samples = X_t.shape
 
         select_samples_far_from_centroid_kernel = (
             make_select_samples_far_from_centroid_kernel(
-                n_empty_clusters, n_samples, work_group_size
+                n_empty_clusters, n_samples, self.work_group_size
             )
         )
 
@@ -609,7 +587,7 @@ class KMeansDriver:
             n_empty_clusters,
             n_features,
             n_selected_gt_threshold_,
-            work_group_size,
+            self.work_group_size,
             compute_dtype,
         )
 
@@ -646,21 +624,44 @@ class KMeansDriver:
     def _get_labels_inertia(
         self, X, centers, sample_weight=_IgnoreSampleWeight, with_inertia=True
     ):
-
-        (
-            X,
-            sample_weight,
-            centers,
-            compute_dtype,
-            output_dtype,
-            work_group_size,
-        ) = self._check_inputs(
+        (X, sample_weight, centers, output_dtype,) = self._check_inputs(
             X,
             sample_weight=sample_weight,
             cluster_centers=centers,
         )
-        n_samples, n_features = X.shape
-        n_clusters = centers.shape[0]
+
+        if sample_weight is _IgnoreSampleWeight:
+            sample_weight = None
+
+        X_t, sample_weight, centroids_t = self._load_transposed_data_to_device(
+            X,
+            sample_weight,
+            centers,
+        )
+
+        assignments_idx, inertia = self._driver_get_labels_inertia(
+            X_t,
+            centroids_t,
+            sample_weight,
+            with_inertia,
+        )
+
+        if with_inertia:
+            # inertia is a 1-sized numpy array, we transform it into a scalar:
+            inertia = inertia.astype(output_dtype)[0]
+
+        return assignments_idx, inertia
+
+    def _driver_get_labels_inertia(
+        self,
+        X_t,
+        centroids_t,
+        sample_weight,
+        with_inertia,
+    ):
+        compute_dtype = X_t.dtype.type
+        n_features, n_samples = X_t.shape
+        n_clusters = centroids_t.shape[1]
 
         label_assignment_fixed_window_kernel = make_label_assignment_fixed_window_kernel(
             n_samples,
@@ -669,24 +670,15 @@ class KMeansDriver:
             preferred_work_group_size_multiple=self.preferred_work_group_size_multiple,
             centroids_window_width_multiplier=self.centroids_window_width_multiplier,
             centroids_window_height=self.centroids_window_height,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
 
         half_l2_norm_kernel = make_half_l2_norm_2d_axis0_kernel(
             size0=n_features,
             size1=n_clusters,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
-        )
-
-        if (sample_weight is _IgnoreSampleWeight) and not with_inertia:
-            sample_weight = None
-
-        X_t, sample_weight, centroids_t = self._load_transposed_data_to_device(
-            X,
-            sample_weight,
-            centers,
         )
 
         centroids_half_l2_norm = dpt.empty(
@@ -709,13 +701,13 @@ class KMeansDriver:
         compute_inertia_kernel = make_compute_inertia_kernel(
             n_samples,
             n_features,
-            work_group_size,
+            self.work_group_size,
             compute_dtype,
         )
 
         reduce_inertia_kernel = make_sum_reduction_1d_kernel(
             size=n_samples,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             device=self.device,
             dtype=compute_dtype,
         )
@@ -734,28 +726,30 @@ class KMeansDriver:
 
         # inertia = per_sample_inertia.sum()
         inertia = dpt.asnumpy(reduce_inertia_kernel(per_sample_inertia))
-        # inertia is now a 1-sized numpy array, we transform it into a scalar:
-        inertia = inertia.astype(output_dtype)[0]
 
         return assignments_idx, inertia
 
     def get_euclidean_distances(self, X, Y):
 
-        euclidean_distances, output_dtype = self._get_euclidean_distances(
-            X,
-            Y,
-        )
-
-        return dpt.asnumpy(euclidean_distances).astype(output_dtype, copy=False)
-
-    def _get_euclidean_distances(self, X, Y):
-        (X, _, Y, compute_dtype, output_dtype, work_group_size,) = self._check_inputs(
+        (X, _, Y, output_dtype) = self._check_inputs(
             X,
             sample_weight=_IgnoreSampleWeight,
             cluster_centers=Y,
         )
-        n_samples, n_features = X.shape
-        n_clusters = Y.shape[0]
+
+        X_t, _, Y_t = self._load_transposed_data_to_device(X, None, Y)
+
+        euclidean_distances = self._get_euclidean_distances(
+            X_t,
+            Y_t,
+        )
+
+        return dpt.asnumpy(euclidean_distances).astype(output_dtype, copy=False)
+
+    def _get_euclidean_distances(self, X_t, Y_t):
+        compute_dtype = X_t.dtype.type
+        n_features, n_samples = X_t.shape
+        n_clusters = Y_t.shape[1]
 
         euclidean_distances_fixed_window_kernel = make_compute_euclidean_distances_fixed_window_kernel(
             n_samples,
@@ -764,11 +758,9 @@ class KMeansDriver:
             preferred_work_group_size_multiple=self.preferred_work_group_size_multiple,
             centroids_window_width_multiplier=self.centroids_window_width_multiplier,
             centroids_window_height=self.centroids_window_height,
-            work_group_size=work_group_size,
+            work_group_size=self.work_group_size,
             dtype=compute_dtype,
         )
-
-        X_t, _, Y_t = self._load_transposed_data_to_device(X, None, Y)
 
         euclidean_distances_t = dpt.empty(
             (n_clusters, n_samples), dtype=compute_dtype, device=self.device
@@ -779,11 +771,10 @@ class KMeansDriver:
             Y_t,
             euclidean_distances_t,
         )
-        return euclidean_distances_t.T, output_dtype
+        return euclidean_distances_t.T
 
     def _set_dtype(self, X, sample_weight, centers_init):
-        input_dtype = output_dtype = np.dtype(X.dtype).type
-        compute_dtype = np.dtype(self.dtype or input_dtype).type
+        output_dtype = compute_dtype = np.dtype(X.dtype).type
         copy = True
         if (compute_dtype != np.float32) and (compute_dtype != np.float64):
             text = (
@@ -799,11 +790,6 @@ class KMeansDriver:
                 f"will default back to float32 type."
             )
             compute_dtype = np.float32
-        elif compute_dtype != X.dtype:
-            text = (
-                f"KMeans is set to run with dtype {compute_dtype} but the data has "
-                f"been submitted with type {X.dtype}."
-            )
 
         else:
             copy = False
@@ -845,32 +831,25 @@ class KMeansDriver:
             )
             sample_weight = sample_weight.astype(compute_dtype)
 
-        return X, sample_weight, centers_init, compute_dtype, output_dtype
+        return X, sample_weight, centers_init, output_dtype
 
     def _check_inputs(self, X, sample_weight, cluster_centers):
 
         if sample_weight is None:
-            sample_weight = np.ones(len(X), dtype=(self.dtype or X.dtype))
+            sample_weight = np.ones(len(X), dtype=X.dtype)
 
         (
             X,
             sample_weight,
             cluster_centers,
-            compute_dtype,
             output_dtype,
         ) = self._set_dtype(X, sample_weight, cluster_centers)
-
-        work_group_size = (
-            self.work_group_size_multiplier * self.preferred_work_group_size_multiple
-        )
 
         return (
             X,
             sample_weight,
             cluster_centers,
-            compute_dtype,
             output_dtype,
-            work_group_size,
         )
 
     def _load_transposed_data_to_device(self, X, sample_weight, cluster_centers):

--- a/sklearn_numba_dpex/kmeans/kernels/compute_inertia.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_inertia.py
@@ -6,12 +6,7 @@ import numba_dpex as dpex
 
 
 @lru_cache
-def make_compute_inertia_kernel(
-    n_samples,
-    n_features,
-    work_group_size,
-    dtype,
-):
+def make_compute_inertia_kernel(n_samples, n_features, work_group_size, dtype):
 
     zero_idx = np.int64(0)
     zero_init = dtype(0.0)

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -225,7 +225,7 @@ def make_lloyd_single_step_fixed_window_kernel(
                     first_feature_idx,
                     X_t,
                     centroids_window,
-                    dot_products,
+                    dot_products
                 )
 
                 # When the next iteration starts work items will overwrite shared memory

--- a/sklearn_numba_dpex/kmeans/kernels/utils.py
+++ b/sklearn_numba_dpex/kmeans/kernels/utils.py
@@ -10,11 +10,7 @@ zero_idx = np.int64(0)
 
 @lru_cache
 def make_relocate_empty_clusters_kernel(
-    n_relocated_clusters,
-    n_features,
-    n_selected_gt_threshold,
-    work_group_size,
-    dtype,
+    n_relocated_clusters, n_features, n_selected_gt_threshold, work_group_size, dtype
 ):
     n_work_groups_for_cluster = math.ceil(n_features / work_group_size)
     n_work_items_for_cluster = n_work_groups_for_cluster * work_group_size


### PR DESCRIPTION
The goal now that our KMeans is complete is to work toward enabling the use of the estimators with the `sklearn_numba_dpex` engine with inputs that are not numpy arrays but dpnp arrays or dpt tensors, with a satisfying level of input validation, and while keeping the level of features that we currently have (in particular testing against sklearn unit tests).

It is harder than it sounds and I've been running in circle trying to achieve this, I'll work toward a sequence of small PRs to make data conversions easier to track, by:

- decoupling data validation/conversion steps and actual compute
- leveraging "compute follow data" model to minimize the number of occurences of data parameters in the pipeline

This PR is a small refactoring of the KMeans driver where the data conversion steps are extracted from the driver functions.