### PR TITLE
ENH Fix kernels that wasted overhead compute on out-of-bounds memory

### DIFF
--- a/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
+++ b/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
@@ -4,150 +4,410 @@ import numpy as np
 import numba_dpex as dpex
 
 
-def _make_initialize_window_kernel_funcs(
-    n_clusters,
+def make_pairwise_ops_base_kernel_funcs(
+    n_samples,
     n_features,
-    work_group_size,
-    window_n_centroids,
+    n_clusters,
     window_n_features,
+    window_n_centroids,
+    ops,
     dtype,
+    work_group_size,
     initialize_window_of_centroids_half_l2_norms=False,
 ):
-    zero = dtype(0.0)
-    zero_idx = np.int64(0)
-    inf = dtype(math.inf)
+    # The kernel funcs in this file must behave differently depending on wether the
+    # window over the array of centroids, which has a fixed size, cover a full set of
+    # elements of the array (_full window_), or a partial set of elements (_last
+    # window_), which can happen for the last windows along each dimension, if the size
+    # of the window along said dimensions does not divide the size of the array of
+    # centroids. Indeed, for such windows, the loops on the elements of the window must
+    # be interrupted early to not include compute that would correspond to out-of-bounds
+    # elements in the array of centroids (which would, in this case, cause extra
+    # compute time that, depending on the case, could noticeably hurt the performance).
 
-    n_window_features_per_work_group = work_group_size // window_n_centroids
+    # Unfortunately, `numba_dpex` does not offer tools that would enable at the same
+    # time re-using the same kernel functions for the different cases, and passing the
+    # relevant variables (here, `window_n_centroids`, `last_window_n_centroids`,
+    # `window_n_features` and `last_window_n_features`), whose value is known at
+    # compile time, as constant variables (which can benefit performance). This
+    # function proposes a best effort at keeping things the most possibly factorized
+    # and readable, while enabling passing the variables as compile-time constants.
+    # It consists in instanciating a kernel functions for each different value the
+    # variables can take, and adding conditional switches to use the appropriate
+    # instance depending on the state of the main loop over the windows
+    # (`is_last_centroid_window`, `is_last_feature_window`)
 
-    centroids_window_height_ratio_multiplier = (
-        window_n_features // n_window_features_per_work_group
+    last_window_n_centroids = ((n_clusters - 1) % window_n_centroids) + 1
+    last_window_n_features = ((n_features - 1) % window_n_features) + 1
+
+    initialize_window_of_centroids_factory = _InitializeWindowKernelFuncFactory(
+        dtype,
+        initialize_window_of_centroids_half_l2_norms=initialize_window_of_centroids_half_l2_norms,
+    )
+
+    initialize_full_window_of_centroids = initialize_window_of_centroids_factory.make(
+        window_n_centroids
+    )
+    initialize_last_window_of_centroids = initialize_window_of_centroids_factory.make(
+        last_window_n_centroids
+    )
+
+    if initialize_window_of_centroids_half_l2_norms:
+
+        @dpex.func
+        def initialize_window_of_centroids(
+            local_work_id,
+            first_centroid_idx,
+            centroids_half_l2_norm,
+            window_of_centroids_half_l2_norms,
+            dot_products,
+            is_last_centroid_window,
+        ):
+            if is_last_centroid_window:
+                initialize_last_window_of_centroids(
+                    local_work_id,
+                    first_centroid_idx,
+                    centroids_half_l2_norm,
+                    window_of_centroids_half_l2_norms,
+                    dot_products,
+                )
+            else:
+                initialize_full_window_of_centroids(
+                    local_work_id,
+                    first_centroid_idx,
+                    centroids_half_l2_norm,
+                    window_of_centroids_half_l2_norms,
+                    dot_products,
+                )
+
+    else:
+
+        @dpex.func
+        def initialize_window_of_centroids(dot_products, is_last_centroid_window):
+            if is_last_centroid_window:
+                initialize_last_window_of_centroids(dot_products)
+            else:
+                initialize_full_window_of_centroids(dot_products)
+
+    load_window_of_centroids_and_features_factory = _LoadWindowKernelFuncsFactory(
+        n_clusters, n_features, work_group_size, window_n_centroids, dtype
+    )
+
+    load_full_window_of_centroids_and_features = (
+        load_window_of_centroids_and_features_factory.make(window_n_features)
+    )
+
+    load_last_feature_window_of_centroids_and_features = (
+        load_window_of_centroids_and_features_factory.make(window_n_features)
     )
 
     @dpex.func
-    # fmt: off
-    def _load_window_of_centroids_and_features(
-        first_feature_idx,              # PARAM
-        loading_centroid_idx,           # PARAM
-        window_loading_centroid_idx,    # PARAM
-        window_loading_feature_offset,  # PARAM
-        current_centroids_t,            # IN
-        centroids_window,               # OUT
+    def load_window_of_centroids_and_features(
+        first_feature_idx,
+        loading_centroid_idx,
+        window_loading_centroid_idx,
+        window_loading_feature_offset,
+        current_centroids_t,
+        centroids_window,
+        is_last_feature_window,
     ):
-    # fmt: on
-        centroid_window_first_loading_feature_idx = zero_idx
-
-        # The work items in the work group cooperatively load the values in shared 
-        # memory. At each iteration, the work item loads one value and adjacent work 
-        # items load adjacent values.
-        for _2 in range(centroids_window_height_ratio_multiplier):
-            window_loading_feature_idx = (
-                centroid_window_first_loading_feature_idx
-                + window_loading_feature_offset
-            )
-            loading_feature_idx = first_feature_idx + window_loading_feature_idx
-
-            if (loading_feature_idx < n_features) and (
-                loading_centroid_idx < n_clusters
-            ):
-                value = current_centroids_t[loading_feature_idx, loading_centroid_idx]
-            else:
-                value = zero
-
-            centroids_window[
-                window_loading_feature_idx, window_loading_centroid_idx
-            ] = value
-
-            centroid_window_first_loading_feature_idx += (
-                n_window_features_per_work_group
+        if is_last_feature_window:
+            load_last_feature_window_of_centroids_and_features(
+                first_feature_idx,
+                loading_centroid_idx,
+                window_loading_centroid_idx,
+                window_loading_feature_offset,
+                current_centroids_t,
+                centroids_window,
             )
 
-    @dpex.func
-    def _initialize_results(results):
-        # Initialize the partial pseudo inertia dot product for each
-        # of the window_n_centroids centroids in the window.
-        for i in range(window_n_centroids):
-            results[i] = zero
+        else:
+            load_full_window_of_centroids_and_features(
+                first_feature_idx,
+                loading_centroid_idx,
+                window_loading_centroid_idx,
+                window_loading_feature_offset,
+                current_centroids_t,
+                centroids_window,
+            )
 
-    if not initialize_window_of_centroids_half_l2_norms:
-        return _initialize_results, _load_window_of_centroids_and_features
+    accumulate_dot_products_factory = _AccumulateSumOfOpsKernelFuncFactory(
+        n_samples,
+        n_features,
+        ops=ops,
+        dtype=dtype,
+    )
+
+    accumulate_full_window_dot_products = accumulate_dot_products_factory.make(
+        window_n_features,
+        window_n_centroids,
+    )
+
+    accumulate_last_centroid_window_dot_products = accumulate_dot_products_factory.make(
+        window_n_features,
+        last_window_n_centroids,
+    )
+
+    accumulate_last_feature_window_dot_products = accumulate_dot_products_factory.make(
+        last_window_n_features,
+        window_n_centroids,
+    )
+
+    accumulate_last_centroid_and_last_feature_window_dot_products = (
+        accumulate_dot_products_factory.make(
+            last_window_n_features,
+            last_window_n_centroids,
+        )
+    )
 
     @dpex.func
-    # fmt: off
-    def _initialize_window_of_centroids(
-        local_work_id,                  # PARAM
-        first_centroid_idx,             # PARAM
-        centroids_half_l2_norm,         # IN
-        window_of_centroids_half_l2_norms,  # OUT
-        results,                        # OUT
+    def accumulate_dot_products(
+        sample_idx,
+        first_feature_idx,
+        X_t,
+        centroids_window,
+        dot_products,
+        is_last_feature_window,
+        is_last_centroid_window,
     ):
-    # fmt: on
-        _initialize_results(results)
+        if is_last_feature_window and is_last_centroid_window:
+            accumulate_last_centroid_and_last_feature_window_dot_products(
+                sample_idx, first_feature_idx, X_t, centroids_window, dot_products
+            )
+        elif is_last_feature_window:
+            accumulate_last_feature_window_dot_products(
+                sample_idx, first_feature_idx, X_t, centroids_window, dot_products
+            )
+        elif is_last_centroid_window:
+            accumulate_last_centroid_window_dot_products(
+                sample_idx, first_feature_idx, X_t, centroids_window, dot_products
+            )
+        else:
+            accumulate_full_window_dot_products(
+                sample_idx, first_feature_idx, X_t, centroids_window, dot_products
+            )
 
-        # The first `window_n_centroids` work items cooperate on loading the
-        # values of centroids_half_l2_norm relevant to current window. Each work
-        # item loads one single value.
-        half_l2_norm_loading_idx = first_centroid_idx + local_work_id
-        if local_work_id < window_n_centroids:
-            if half_l2_norm_loading_idx < n_clusters:
-                l2norm = centroids_half_l2_norm[half_l2_norm_loading_idx]
-            else:
-                l2norm = inf
-            window_of_centroids_half_l2_norms[local_work_id] = l2norm
-
-    return _initialize_window_of_centroids, _load_window_of_centroids_and_features
+    return (
+        initialize_window_of_centroids,
+        load_window_of_centroids_and_features,
+        accumulate_dot_products,
+    )
 
 
-def _make_accumulate_sum_of_ops_kernel_func(
-    n_samples, n_features, window_n_features, window_n_centroids, ops, dtype
-):
-
-    zero = dtype(0.0)
-
-    accumulate_dot_product = ops == "product"
-    accumulate_squared_diff = ops == "squared_diff"
-
-    if not accumulate_dot_product and not accumulate_squared_diff:
-        raise ValueError(
-            f'Expected ops to take values "product" or "squared_diff", got "{ops}" '
-            "instead."
+class _InitializeWindowKernelFuncFactory:
+    def __init__(
+        self,
+        dtype,
+        initialize_window_of_centroids_half_l2_norms,
+    ):
+        self.dtype = dtype
+        self.initialize_window_of_centroids_half_l2_norms = (
+            initialize_window_of_centroids_half_l2_norms
         )
 
-    @dpex.func
-    # fmt: off
-    def _accumulate_sum_of_ops(
-        sample_idx,          # PARAM
-        first_feature_idx,   # PARAM
-        X_t,                 # IN
-        centroids_window,    # IN
-        result,              # OUT
+    def make(self, window_n_centroids):
+        zero = self.dtype(0.0)
+
+        @dpex.func
+        def _initialize_results(results):
+            # Initialize the partial pseudo inertia dot product for each
+            # of the window_n_centroids centroids in the window.
+            for i in range(window_n_centroids):
+                results[i] = zero
+
+        if not self.initialize_window_of_centroids_half_l2_norms:
+            return _initialize_results
+
+        @dpex.func
+        # fmt: off
+        def _initialize_window_of_centroids(
+            local_work_id,                  # PARAM
+            first_centroid_idx,             # PARAM
+            centroids_half_l2_norm,         # IN
+            window_of_centroids_half_l2_norms,  # OUT
+            results,                        # OUT
+        ):
+        # fmt: on
+            _initialize_results(results)
+
+            # The first `window_n_centroids` work items cooperate on loading the
+            # values of centroids_half_l2_norm relevant to current window. Each work
+            # item loads one single value.
+            if local_work_id < window_n_centroids:
+                half_l2_norm_loading_idx = first_centroid_idx + local_work_id
+                window_of_centroids_half_l2_norms[local_work_id] = centroids_half_l2_norm[
+                    half_l2_norm_loading_idx]
+
+        return _initialize_window_of_centroids
+
+
+class _LoadWindowKernelFuncsFactory:
+    def __init__(
+        self, n_clusters, n_features, work_group_size, window_n_centroids, dtype
     ):
-    # fmt: on
-        for window_feature_idx in range(window_n_features):
+        self.n_clusters = n_clusters
+        self.n_features = n_features
+        self.work_group_size = work_group_size
+        self.window_n_centroids = window_n_centroids
+        self.dtype = dtype
 
-            feature_idx = window_feature_idx + first_feature_idx
-            if (feature_idx < n_features) and (sample_idx < n_samples):
-                # performance for the line thereafter relies on L1 cache
-                X_value = X_t[feature_idx, sample_idx]
-            else:
-                X_value = zero
+    def make(self, window_n_features):
+        n_features = self.n_features
+        n_clusters = self.n_clusters
 
-            # For this given feature, loop on all centroids in the current
-            # window and accumulate the partial results
-            for window_centroid_idx in range(window_n_centroids):
-                centroid_value = centroids_window[window_feature_idx, window_centroid_idx]
-                if accumulate_dot_product:
-                    result[window_centroid_idx] += centroid_value * X_value
+        zero = self.dtype(0.0)
+        zero_idx = np.int64(0)
+
+        n_window_features_per_work_group = (
+            self.work_group_size // self.window_n_centroids
+        )
+
+        centroids_window_height_ratio_multiplier = math.ceil(
+            window_n_features / n_window_features_per_work_group
+        )
+
+        @dpex.func
+        # fmt: off
+        def _load_window_of_centroids_and_features(
+            first_feature_idx,              # PARAM
+            loading_centroid_idx,           # PARAM
+            window_loading_centroid_idx,    # PARAM
+            window_loading_feature_offset,  # PARAM
+            current_centroids_t,            # IN
+            centroids_window,               # OUT
+        ):
+        # fmt: on
+            centroid_window_first_loading_feature_idx = zero_idx
+
+            # The work items in the work group cooperatively load the values in shared
+            # memory. At each iteration, the work item loads one value and adjacent work
+            # items load adjacent values.
+            for _2 in range(centroids_window_height_ratio_multiplier):
+                window_loading_feature_idx = (
+                    centroid_window_first_loading_feature_idx
+                    + window_loading_feature_offset
+                )
+                loading_feature_idx = first_feature_idx + window_loading_feature_idx
+
+                if (loading_feature_idx < n_features) and (
+                    loading_centroid_idx < n_clusters
+                ):
+                    value = current_centroids_t[loading_feature_idx, loading_centroid_idx]
                 else:
-                    diff = centroid_value - X_value
-                    result[window_centroid_idx] += diff * diff
+                    value = zero
 
-    return _accumulate_sum_of_ops
+                centroids_window[
+                    window_loading_feature_idx, window_loading_centroid_idx
+                ] = value
+
+                centroid_window_first_loading_feature_idx += (
+                    n_window_features_per_work_group
+                )
+
+        return _load_window_of_centroids_and_features
+
+
+class _AccumulateSumOfOpsKernelFuncFactory:
+    def __init__(self, n_samples, n_features, ops, dtype):
+        self.n_samples = n_samples
+        self.n_features = n_features
+
+        self.accumulate_dot_product = ops == "product"
+        self.accumulate_squared_diff = ops == "squared_diff"
+
+        if not self.accumulate_dot_product and not self.accumulate_squared_diff:
+            raise ValueError(
+                f'Expected ops to take values "product" or "squared_diff", got "{ops}" '
+                "instead."
+            )
+        self.dtype = dtype
+
+    def make(self, window_n_features, window_n_centroids):
+
+        zero = self.dtype(0.0)
+        n_features = self.n_features
+        n_samples = self.n_samples
+        accumulate_dot_product = self.accumulate_dot_product
+
+        @dpex.func
+        # fmt: off
+        def _accumulate_sum_of_ops(
+            sample_idx,          # PARAM
+            first_feature_idx,   # PARAM
+            X_t,                 # IN
+            centroids_window,    # IN
+            result,              # OUT
+        ):
+        # fmt: on
+            for window_feature_idx in range(window_n_features):
+
+                feature_idx = window_feature_idx + first_feature_idx
+                if (feature_idx < n_features) and (sample_idx < n_samples):
+                # if sample_idx < n_samples:
+                    # performance for the line thereafter relies on L1 cache
+                    X_value = X_t[feature_idx, sample_idx]
+                else:
+                    X_value = zero
+
+                # For this given feature, loop on all centroids in the current
+                # window and accumulate the partial results
+                for window_centroid_idx in range(window_n_centroids):
+                    centroid_value = centroids_window[window_feature_idx, window_centroid_idx]
+                    if accumulate_dot_product:
+                        result[window_centroid_idx] += centroid_value * X_value
+                    else:
+                        diff = centroid_value - X_value
+                        result[window_centroid_idx] += diff * diff
+
+        return _accumulate_sum_of_ops
+
+
+def make_update_closest_centroid_kernel_func(n_clusters, window_n_centroids):
+
+    last_window_n_centroids = ((n_clusters - 1) % window_n_centroids) + 1
+
+    update_closest_centroid_full = _make_update_closest_centroid_kernel_func(
+        window_n_centroids
+    )
+
+    update_last_closest_centroid = _make_update_closest_centroid_kernel_func(
+        last_window_n_centroids
+    )
+
+    @dpex.func
+    def update_closest_centroid(
+        first_centroid_idx,
+        min_idx,
+        min_sample_pseudo_inertia,
+        window_of_centroids_half_l2_norms,
+        dot_products,
+        is_last_centroid_window,
+    ):
+
+        if is_last_centroid_window:
+            return update_last_closest_centroid(
+                first_centroid_idx,
+                min_idx,
+                min_sample_pseudo_inertia,
+                window_of_centroids_half_l2_norms,
+                dot_products,
+            )
+        else:
+            return update_closest_centroid_full(
+                first_centroid_idx,
+                min_idx,
+                min_sample_pseudo_inertia,
+                window_of_centroids_half_l2_norms,
+                dot_products,
+            )
+
+    return update_closest_centroid
 
 
 def _make_update_closest_centroid_kernel_func(window_n_centroids):
     @dpex.func
     # fmt: off
-    def _update_closest_centroid(
+    def update_closest_centroid(
         first_centroid_idx,                  # PARAM
         min_idx,                             # PARAM
         min_sample_pseudo_inertia,           # PARAM
@@ -164,4 +424,4 @@ def _make_update_closest_centroid_kernel_func(window_n_centroids):
                 min_idx = first_centroid_idx + i
         return min_idx, min_sample_pseudo_inertia
 
-    return _update_closest_centroid
+    return update_closest_centroid

--- a/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
+++ b/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
@@ -302,7 +302,7 @@ class _LoadWindowKernelFuncsFactory:
 
 
 class _AccumulateSumOfOpsKernelFuncFactory:
-    def __init__(self, n_samples, n_features, ops, dtype):
+    def __init__(self, n_samples, ops, dtype):
         self.n_samples = n_samples
 
         self.accumulate_dot_product = ops == "product"

--- a/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
+++ b/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
@@ -15,15 +15,17 @@ def make_pairwise_ops_base_kernel_funcs(
     work_group_size,
     initialize_window_of_centroids_half_l2_norms=False,
 ):
-    # The kernel funcs in this file must behave differently depending on wether the
-    # window over the array of centroids, which has a fixed size, cover a full set of
-    # elements of the array (_full window_), or a partial set of elements (_last
-    # window_), which can happen for the last windows along each dimension, if the size
-    # of the window along said dimensions does not divide the size of the array of
-    # centroids. Indeed, for such windows, the loops on the elements of the window must
-    # be interrupted early to not include compute that would correspond to out-of-bounds
+    # The kernel funcs in this file must behave differently depending on whether the
+    # window over the array of centroids (which has a fixed size):
+    #    - covers a full set of elements of the array (_full window_),
+    #    - covers a partial set of elements (_last window_), which can happen for
+    #      the last windows along each dimension if the size of the window along
+    #      said dimensions does not divide the size of the array of centroids.
+    #
+    # Indeed, for such windows, the loops on the elements of the window must  be
+    # interrupted early to not include compute that would correspond to out-of-bounds
     # elements in the array of centroids (which would, in this case, cause extra
-    # compute time that, depending on the case, could noticeably hurt the performance).
+    # compute time that, depending on the case, could noticeably hurt performance).
 
     # Unfortunately, `numba_dpex` does not offer tools that would enable at the same
     # time re-using the same kernel functions for the different cases, and passing the
@@ -41,8 +43,7 @@ def make_pairwise_ops_base_kernel_funcs(
     last_window_n_features = ((n_features - 1) % window_n_features) + 1
 
     initialize_window_of_centroids_factory = _InitializeWindowKernelFuncFactory(
-        dtype,
-        initialize_window_of_centroids_half_l2_norms=initialize_window_of_centroids_half_l2_norms,
+        dtype, initialize_window_of_centroids_half_l2_norms
     )
 
     initialize_full_window_of_centroids = initialize_window_of_centroids_factory.make(
@@ -132,31 +133,24 @@ def make_pairwise_ops_base_kernel_funcs(
             )
 
     accumulate_dot_products_factory = _AccumulateSumOfOpsKernelFuncFactory(
-        n_samples,
-        n_features,
-        ops=ops,
-        dtype=dtype,
+        n_samples, ops=ops, dtype=dtype
     )
 
     accumulate_full_window_dot_products = accumulate_dot_products_factory.make(
-        window_n_features,
-        window_n_centroids,
+        window_n_features, window_n_centroids
     )
 
     accumulate_last_centroid_window_dot_products = accumulate_dot_products_factory.make(
-        window_n_features,
-        last_window_n_centroids,
+        window_n_features, last_window_n_centroids
     )
 
     accumulate_last_feature_window_dot_products = accumulate_dot_products_factory.make(
-        last_window_n_features,
-        window_n_centroids,
+        last_window_n_features, window_n_centroids
     )
 
     accumulate_last_centroid_and_last_feature_window_dot_products = (
         accumulate_dot_products_factory.make(
-            last_window_n_features,
-            last_window_n_centroids,
+            last_window_n_features, last_window_n_centroids
         )
     )
 
@@ -221,11 +215,11 @@ class _InitializeWindowKernelFuncFactory:
         @dpex.func
         # fmt: off
         def _initialize_window_of_centroids(
-            local_work_id,                  # PARAM
-            first_centroid_idx,             # PARAM
-            centroids_half_l2_norm,         # IN
+            local_work_id,                      # PARAM
+            first_centroid_idx,                 # PARAM
+            centroids_half_l2_norm,             # IN
             window_of_centroids_half_l2_norms,  # OUT
-            results,                        # OUT
+            results,                            # OUT
         ):
         # fmt: on
             _initialize_results(results)
@@ -310,7 +304,6 @@ class _LoadWindowKernelFuncsFactory:
 class _AccumulateSumOfOpsKernelFuncFactory:
     def __init__(self, n_samples, n_features, ops, dtype):
         self.n_samples = n_samples
-        self.n_features = n_features
 
         self.accumulate_dot_product = ops == "product"
         self.accumulate_squared_diff = ops == "squared_diff"
@@ -325,7 +318,6 @@ class _AccumulateSumOfOpsKernelFuncFactory:
     def make(self, window_n_features, window_n_centroids):
 
         zero = self.dtype(0.0)
-        n_features = self.n_features
         n_samples = self.n_samples
         accumulate_dot_product = self.accumulate_dot_product
 
@@ -342,8 +334,7 @@ class _AccumulateSumOfOpsKernelFuncFactory:
             for window_feature_idx in range(window_n_features):
 
                 feature_idx = window_feature_idx + first_feature_idx
-                if (feature_idx < n_features) and (sample_idx < n_samples):
-                # if sample_idx < n_samples:
+                if sample_idx < n_samples:
                     # performance for the line thereafter relies on L1 cache
                     X_value = X_t[feature_idx, sample_idx]
                 else:

--- a/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
+++ b/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
@@ -40,8 +40,9 @@ def make_pairwise_ops_base_kernel_funcs(
     # (`is_last_centroid_window`, `is_last_feature_window`)
 
     kmeans_kernel_func_factory = _KMeansKernelFuncFactory(
-        n_clusters,
+        n_samples,
         n_features,
+        n_clusters,
         window_n_centroids,
         ops,
         dtype,
@@ -206,16 +207,18 @@ def make_pairwise_ops_base_kernel_funcs(
 class _KMeansKernelFuncFactory:
     def __init__(
         self,
-        n_clusters,
+        n_samples,
         n_features,
+        n_clusters,
         full_window_n_centroids,
         ops,
         dtype,
         work_group_size,
         initialize_window_of_centroids_half_l2_norms,
     ):
-        self.n_clusters = n_clusters
+        self.n_samples = n_samples
         self.n_features = n_features
+        self.n_clusters = n_clusters
         self.work_group_size = work_group_size
         self.full_window_n_centroids = full_window_n_centroids
 

--- a/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
@@ -36,9 +36,9 @@ def make_compute_euclidean_distances_fixed_window_kernel(
         n_clusters,
         centroids_window_height,
         window_n_centroids,
-        "squared_diff",
-        dtype,
-        work_group_size,
+        ops="squared_diff",
+        dtype=dtype,
+        work_group_size=work_group_size,
         initialize_window_of_centroids_half_l2_norms=False,
     )
 
@@ -93,7 +93,14 @@ def make_compute_euclidean_distances_fixed_window_kernel(
                 )
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
-                accumulate_sq_distances(sample_idx, first_feature_idx, X_t, centroids_window, sq_distances, is_last_feature_window, is_last_centroid_window)
+                accumulate_sq_distances(
+                    sample_idx,
+                    first_feature_idx,
+                    X_t,
+                    centroids_window,
+                    sq_distances,
+                    is_last_feature_window,
+                    is_last_centroid_window)
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 

--- a/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
@@ -4,10 +4,7 @@ from functools import lru_cache
 import numpy as np
 import numba_dpex as dpex
 
-from ._base_kmeans_kernel_funcs import (
-    _make_initialize_window_kernel_funcs,
-    _make_accumulate_sum_of_ops_kernel_func,
-)
+from ._base_kmeans_kernel_funcs import make_pairwise_ops_base_kernel_funcs
 
 # NB: refer to the definition of the main lloyd function for a more comprehensive
 # inline commenting of the kernel.
@@ -30,28 +27,25 @@ def make_compute_euclidean_distances_fixed_window_kernel(
     )
 
     (
-        _initialize_window_of_centroids,
-        _load_window_of_centroids_and_features,
-    ) = _make_initialize_window_kernel_funcs(
-        n_clusters,
-        n_features,
-        work_group_size,
-        window_n_centroids,
-        centroids_window_height,
-        dtype,
-    )
-
-    _accumulate_sq_distances = _make_accumulate_sum_of_ops_kernel_func(
+        initialize_window_of_centroids,
+        load_window_of_centroids_and_features,
+        accumulate_sq_distances,
+    ) = make_pairwise_ops_base_kernel_funcs(
         n_samples,
         n_features,
+        n_clusters,
         centroids_window_height,
         window_n_centroids,
-        ops="squared_diff",
-        dtype=dtype,
+        "squared_diff",
+        dtype,
+        work_group_size,
+        initialize_window_of_centroids_half_l2_norms=False,
     )
 
     n_windows_for_centroids = math.ceil(n_clusters / window_n_centroids)
     n_windows_for_features = math.ceil(n_features / centroids_window_height)
+    last_centroid_window_idx = n_windows_for_centroids - 1
+    last_feature_window_idx = n_windows_for_features - 1
 
     centroids_window_shape = (centroids_window_height, (window_n_centroids + 1))
 
@@ -79,24 +73,27 @@ def make_compute_euclidean_distances_fixed_window_kernel(
         window_loading_feature_offset = local_work_id // window_n_centroids
 
         for _0 in range(n_windows_for_centroids):
-            _initialize_window_of_centroids(sq_distances)
+            is_last_centroid_window = _0 == last_centroid_window_idx
+            initialize_window_of_centroids(sq_distances, is_last_centroid_window)
 
             loading_centroid_idx = first_centroid_idx + window_loading_centroid_idx
 
             first_feature_idx = zero_idx
 
             for _1 in range(n_windows_for_features):
-                _load_window_of_centroids_and_features(
+                is_last_feature_window = _1 == last_feature_window_idx
+                load_window_of_centroids_and_features(
                     first_feature_idx,
                     loading_centroid_idx,
                     window_loading_centroid_idx,
                     window_loading_feature_offset,
                     current_centroids_t,
                     centroids_window,
+                    is_last_feature_window
                 )
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
-                _accumulate_sq_distances(sample_idx, first_feature_idx, X_t, centroids_window, sq_distances)
+                accumulate_sq_distances(sample_idx, first_feature_idx, X_t, centroids_window, sq_distances, is_last_feature_window, is_last_centroid_window)
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 

--- a/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
@@ -72,16 +72,16 @@ def make_compute_euclidean_distances_fixed_window_kernel(
         window_loading_centroid_idx = local_work_id % window_n_centroids
         window_loading_feature_offset = local_work_id // window_n_centroids
 
-        for _0 in range(n_windows_for_centroids):
-            is_last_centroid_window = _0 == last_centroid_window_idx
+        for centroid_window_idx in range(n_windows_for_centroids):
+            is_last_centroid_window = centroid_window_idx == last_centroid_window_idx
             initialize_window_of_centroids(sq_distances, is_last_centroid_window)
 
             loading_centroid_idx = first_centroid_idx + window_loading_centroid_idx
 
             first_feature_idx = zero_idx
 
-            for _1 in range(n_windows_for_features):
-                is_last_feature_window = _1 == last_feature_window_idx
+            for feature_window_idx in range(n_windows_for_features):
+                is_last_feature_window = feature_window_idx == last_feature_window_idx
                 load_window_of_centroids_and_features(
                     first_feature_idx,
                     loading_centroid_idx,
@@ -100,7 +100,8 @@ def make_compute_euclidean_distances_fixed_window_kernel(
                     centroids_window,
                     sq_distances,
                     is_last_feature_window,
-                    is_last_centroid_window)
+                    is_last_centroid_window,
+                )
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 

--- a/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
@@ -39,9 +39,9 @@ def make_label_assignment_fixed_window_kernel(
         n_clusters,
         centroids_window_height,
         window_n_centroids,
-        "product",
-        dtype,
-        work_group_size,
+        ops="product",
+        dtype=dtype,
+        work_group_size=work_group_size,
         initialize_window_of_centroids_half_l2_norms=True,
     )
 
@@ -121,7 +121,9 @@ def make_label_assignment_fixed_window_kernel(
                     first_feature_idx,
                     X_t,
                     centroids_window,
-                    dot_products, is_last_feature_window, is_last_centroid_window
+                    dot_products,
+                    is_last_feature_window,
+                    is_last_centroid_window
                 )
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)

--- a/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
@@ -5,9 +5,8 @@ import numpy as np
 import numba_dpex as dpex
 
 from ._base_kmeans_kernel_funcs import (
-    _make_initialize_window_kernel_funcs,
-    _make_update_closest_centroid_kernel_func,
-    _make_accumulate_sum_of_ops_kernel_func,
+    make_pairwise_ops_base_kernel_funcs,
+    make_update_closest_centroid_kernel_func,
 )
 
 # NB: refer to the definition of the main lloyd function for a more comprehensive
@@ -31,33 +30,29 @@ def make_label_assignment_fixed_window_kernel(
     )
 
     (
-        _initialize_window_of_centroids,
-        _load_window_of_centroids_and_features,
-    ) = _make_initialize_window_kernel_funcs(
-        n_clusters,
+        initialize_window_of_centroids,
+        load_window_of_centroids_and_features,
+        accumulate_dot_products,
+    ) = make_pairwise_ops_base_kernel_funcs(
+        n_samples,
         n_features,
-        work_group_size,
-        window_n_centroids,
+        n_clusters,
         centroids_window_height,
+        window_n_centroids,
+        "product",
         dtype,
+        work_group_size,
         initialize_window_of_centroids_half_l2_norms=True,
     )
 
-    _update_closest_centroid = _make_update_closest_centroid_kernel_func(
-        window_n_centroids
-    )
-
-    _accumulate_dot_products = _make_accumulate_sum_of_ops_kernel_func(
-        n_samples,
-        n_features,
-        centroids_window_height,
-        window_n_centroids,
-        ops="product",
-        dtype=dtype,
+    update_closest_centroid = make_update_closest_centroid_kernel_func(
+        n_clusters, window_n_centroids
     )
 
     n_windows_for_centroids = math.ceil(n_clusters / window_n_centroids)
     n_windows_for_features = math.ceil(n_features / centroids_window_height)
+    last_centroid_window_idx = n_windows_for_centroids - 1
+    last_feature_window_idx = n_windows_for_features - 1
 
     centroids_window_shape = (centroids_window_height, (window_n_centroids + 1))
 
@@ -92,12 +87,15 @@ def make_label_assignment_fixed_window_kernel(
         window_loading_feature_offset = local_work_id // window_n_centroids
 
         for _0 in range(n_windows_for_centroids):
-            _initialize_window_of_centroids(
+            is_last_centroid_window = _0 == last_centroid_window_idx
+
+            initialize_window_of_centroids(
                 local_work_id,
                 first_centroid_idx,
                 centroids_half_l2_norm,
                 window_of_centroids_half_l2_norms,
                 dot_products,
+                is_last_centroid_window
             )
 
             loading_centroid_idx = first_centroid_idx + window_loading_centroid_idx
@@ -105,35 +103,38 @@ def make_label_assignment_fixed_window_kernel(
             first_feature_idx = zero_idx
 
             for _1 in range(n_windows_for_features):
-                _load_window_of_centroids_and_features(
+                is_last_feature_window = _1 == last_feature_window_idx
+                load_window_of_centroids_and_features(
                     first_feature_idx,
                     loading_centroid_idx,
                     window_loading_centroid_idx,
                     window_loading_feature_offset,
                     centroids_t,
                     centroids_window,
+                    is_last_feature_window
                 )
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 
-                _accumulate_dot_products(
+                accumulate_dot_products(
                     sample_idx,
                     first_feature_idx,
                     X_t,
                     centroids_window,
-                    dot_products,
+                    dot_products, is_last_feature_window, is_last_centroid_window
                 )
 
                 dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 
                 first_feature_idx += centroids_window_height
 
-            min_idx, min_sample_pseudo_inertia = _update_closest_centroid(
+            min_idx, min_sample_pseudo_inertia = update_closest_centroid(
                 first_centroid_idx,
                 min_idx,
                 min_sample_pseudo_inertia,
                 window_of_centroids_half_l2_norms,
                 dot_products,
+                is_last_centroid_window
             )
 
             dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)

--- a/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
@@ -86,8 +86,8 @@ def make_label_assignment_fixed_window_kernel(
         window_loading_centroid_idx = local_work_id % window_n_centroids
         window_loading_feature_offset = local_work_id // window_n_centroids
 
-        for _0 in range(n_windows_for_centroids):
-            is_last_centroid_window = _0 == last_centroid_window_idx
+        for centroid_window_idx in range(n_windows_for_centroids):
+            is_last_centroid_window = centroid_window_idx == last_centroid_window_idx
 
             initialize_window_of_centroids(
                 local_work_id,
@@ -102,8 +102,8 @@ def make_label_assignment_fixed_window_kernel(
 
             first_feature_idx = zero_idx
 
-            for _1 in range(n_windows_for_features):
-                is_last_feature_window = _1 == last_feature_window_idx
+            for feature_windiw_idx in range(n_windows_for_features):
+                is_last_feature_window = feature_windiw_idx == last_feature_window_idx
                 load_window_of_centroids_and_features(
                     first_feature_idx,
                     loading_centroid_idx,

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -57,9 +57,9 @@ def make_lloyd_single_step_fixed_window_kernel(
         n_clusters,
         centroids_window_height,
         window_n_centroids,
-        "product",
-        dtype,
-        work_group_size,
+        ops="product",
+        dtype=dtype,
+        work_group_size=work_group_size,
         initialize_window_of_centroids_half_l2_norms=True,
     )
 

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -183,10 +183,10 @@ def make_lloyd_single_step_fixed_window_kernel(
         # `numba`. Note though, that `numba` cannot unroll nested loops, so won't
         # `numba_dpex`. To leverage loop unrolling, the following nested loop will
         # require to be un-nested.
-        for _0 in range(n_windows_for_centroids):
+        for centroid_window_idx in range(n_windows_for_centroids):
             # window_of_centroids_half_l2_norms and dot_products
             # are modified in place.
-            is_last_centroid_window = _0 == last_centroid_window_idx
+            is_last_centroid_window = centroid_window_idx == last_centroid_window_idx
             initialize_window_of_centroids(
                 local_work_id,
                 first_centroid_idx,
@@ -202,9 +202,9 @@ def make_lloyd_single_step_fixed_window_kernel(
 
             # Inner loop: interate on successive windows of size window_n_features
             # that cover all features for current given centroids
-            for _1 in range(n_windows_for_features):
+            for feature_window_idx in range(n_windows_for_features):
                 # centroids_window is modified inplace
-                is_last_feature_window = _1 == last_feature_window_idx
+                is_last_feature_window = feature_window_idx == last_feature_window_idx
                 load_window_of_centroids_and_features(
                     first_feature_idx,
                     loading_centroid_idx,


### PR DESCRIPTION
On main branch currently, if the size of the window over centroids does not divide the size of the array of centroids, windows on the edge are filled with zeros, but compute still takes place for those zeros, In unlucky setups (e.g small number of dimensions and/or clusters, and increased size of window) most of the time can be spent there. The fix consists in exiting the loops over elements of the window so that no compute is performed over the extra zero padding.