### PR TITLE
ENH Up to date dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@
 #
 # TODO: make a custom build with other base images to test compatibility
 # with other OSes.
-ARG BASE_IMAGE_VERSION=latest-f3cc5b196af0d6f69df8c67543f160bb73425b5a
+ARG BASE_IMAGE_VERSION=latest-082cde669552482c541a297e38adce4afee4fd34
 ARG BASE_IMAGE_TAG=ghcr.io/intel/llvm/ubuntu2004_intel_drivers
 
 ARG BASE=${BASE_IMAGE_TAG}:${BASE_IMAGE_VERSION}
@@ -71,24 +71,24 @@ ARG PYTHON_VERSION=3.9.13
 # It can be found at https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=linux&distributions=webdownload&options=online
 # The installer CLI is documented here: https://www.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-linux/top/installation/install-with-command-line.html#install-with-command-line_interactive
 
-ARG ONEAPI_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18852
-ARG ONEAPI_INSTALL_BINARY_NAME=l_BaseKit_p_2022.3.0.8767.sh
+ARG ONEAPI_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18970
+ARG ONEAPI_INSTALL_BINARY_NAME=l_BaseKit_p_2022.3.1.17310.sh
 
 ARG ONEAPI_INSTALL_DIR=/opt/intel/oneapi
 
 # Some build steps require a high enough version of cmake.
 # Bump it if necessary.
 
-ARG CMAKE_VERSION=3.24
-ARG CMAKE_VERSION_BUILD=2
+ARG CMAKE_VERSION=3.25
+ARG CMAKE_VERSION_BUILD=0
 
 
 # Versions of the intel python packages
 
-ARG DPCTL_GIT_BRANCH=0.13.0
+ARG DPCTL_GIT_BRANCH=0.14.0rc2
 ARG DPCTL_GIT_URL=https://github.com/IntelPython/dpctl.git
 
-ARG DPNP_GIT_BRANCH=0.10.2
+ARG DPNP_GIT_BRANCH=0.11.0rc1
 ARG DPNP_GIT_URL=https://github.com/IntelPython/dpnp.git
 
 ARG NUMBA_DPEX_GIT_BRANCH=0.18.1

--- a/sklearn_numba_dpex/device/device.py
+++ b/sklearn_numba_dpex/device/device.py
@@ -65,18 +65,6 @@ class DeviceParams:
                 device_name=self.name,
             )
 
-    @property
-    def global_mem_cache_size(self):
-        try:
-            return self._sycl_device.global_mem_cache_size
-        except AttributeError:
-            return _get_cl_param(
-                cl_device=self._cl_device,
-                value="global_mem_cache_size",
-                default=_DEFAULT_VALUES.global_mem_cache_size,
-                device_name=self.name,
-            )
-
 
 def _get_cl_platforms():
     return pyopencl.get_platforms() if pyopencl else []

--- a/sklearn_numba_dpex/device/tests/test_device_params.py
+++ b/sklearn_numba_dpex/device/tests/test_device_params.py
@@ -7,20 +7,6 @@ import pytest
 from sklearn_numba_dpex.device import DeviceParams
 
 
-def test_opencl_requirement():
-    # Detect if https://github.com/IntelPython/dpctl/issues/886 is fixed
-    # upstream and alert that sklearn-numba-dpex can be adapted accordingly.
-    device = dpctl.select_default_device()
-    has_preferred_work_group_size_multiple = hasattr(
-        device, "preferred_work_group_size_multiple"
-    )
-    has_global_mem_cache_size = hasattr(device, "global_mem_cache_size")
-    assert not (has_preferred_work_group_size_multiple or has_global_mem_cache_size), (
-        "pyopencl is not required anymore: update the code to directly use dpctl "
-        "instead, and remove pyopencl from the install_requires list in setup.py ."
-    )
-
-
 def test_warnings_non_cl_device_params():
     @dataclass
     class _FakeSyclDevice:
@@ -32,9 +18,6 @@ def test_warnings_non_cl_device_params():
     # Check that a warning is raised if a device is not detected by opencl
     with pytest.warns(RuntimeWarning):
         device_params.preferred_work_group_size_multiple
-
-    with pytest.warns(RuntimeWarning):
-        device_params.global_mem_cache_size
 
 
 def test_no_warnings_cl_device_params():
@@ -48,4 +31,3 @@ def test_no_warnings_cl_device_params():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         device_params.preferred_work_group_size_multiple
-        device_params.global_mem_cache_size

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -129,7 +129,7 @@ class KMeansDriver:
         # exhaustive grid search.
 
         self.global_mem_cache_size = (
-            global_mem_cache_size or device_params.global_mem_cache_size
+            global_mem_cache_size or dpctl_device.global_mem_cache_size
         )
 
         self.preferred_work_group_size_multiple = check_power_of_2(
@@ -881,7 +881,7 @@ class KMeansDriver:
             # XXX: cannot be supported at this time because of this bug:
             # https://github.com/IntelPython/numba-dpex/issues/767
             #
-            # TODO: when the blocking bug is fixed in `numba_dpex`, remove 
+            # TODO: when the blocking bug is fixed in `numba_dpex`, remove
             # all array transpositions and support the C-layout for X. Benchmark
             # it and default to the layout that gives better performances.
             #


### PR DESCRIPTION
First step towards solving https://github.com/soda-inria/sklearn-numba-dpex/issues/52

The use of `dpctl==0.14.0rc2` unlocks early the use of `dpctl.SyclDevice.sub_group_sizes` if you want to check the values on your machines.

I check that all tests passes before pushing and the benchmark is unchanged.