### PR TITLE
Benchmark: do not report timings under 100ms precision level

### DIFF
--- a/benchmark/kmeans.py
+++ b/benchmark/kmeans.py
@@ -120,7 +120,7 @@ class KMeansLloydTimeit:
             self._check_same_fit(
                 estimator, name, max_iter, assert_allclose=self.run_consistency_checks
             )
-            print(f"Running {name} ... done in {t1 - t0}\n")
+            print(f"Running {name} ... done in {t1 - t0:.1f} s\n")
 
     def _check_same_fit(self, estimator, name, max_iter, assert_allclose):
         runtime_error_message = (


### PR DESCRIPTION
The inter-run variability is typically much larger than 100 ms so there is not point reporting too many falsely significant digits.