### PR TITLE
FEA: engine accepts dpnp.ndarray and dpt.usm_ndarray objects as input data.

### DIFF
--- a/benchmark/ext_helpers/daal4py.py
+++ b/benchmark/ext_helpers/daal4py.py
@@ -29,6 +29,7 @@ finally:
 from sklearn.exceptions import NotSupportedByEngineError
 from sklearn.cluster._kmeans import KMeansCythonEngine
 
+
 # TODO: instead of relying on monkey patching the default engine, find a way to
 # register a distinct entry point that can load a distinct engine outside of setup.py
 # (impossible ?)

--- a/benchmark/kmeans.py
+++ b/benchmark/kmeans.py
@@ -98,8 +98,7 @@ class KMeansLloydTimeit:
 
         print(
             f"Running {name} with parameters sample_weight={self.sample_weight} "
-            f"n_clusters={n_clusters} data_shape={X.shape} max_iter={max_iter} "
-            f"tol={tol} ..."
+            f"n_clusters={n_clusters} data_shape={X.shape} max_iter={max_iter}..."
         )
 
         with sklearn.config_context(engine_provider=engine_provider):
@@ -178,7 +177,6 @@ if __name__ == "__main__":
     init = "k-means++"  # "k-means++" or "random"
     n_clusters = 127
     max_iter = 100
-    tol = 0
     skip_slow = True
     dtype = np.float32
     # NB: it seems that currently the estimators in the benchmark always return

--- a/sklearn_numba_dpex/common/_utils.py
+++ b/sklearn_numba_dpex/common/_utils.py
@@ -5,3 +5,15 @@ def check_power_of_2(e):
     if e != 2 ** (math.log2(e)):
         raise ValueError(f"Expected a power of 2, got {e}")
     return e
+
+
+def _square(x):
+    return x * x
+
+
+def _minus(x, y):
+    return x - y
+
+
+def _plus(x, y):
+    return x + y

--- a/sklearn_numba_dpex/common/kernels.py
+++ b/sklearn_numba_dpex/common/kernels.py
@@ -81,7 +81,8 @@ def make_initialize_to_zeros_3d_kernel(size0, size1, size2, work_group_size, dty
 def make_broadcast_division_1d_2d_axis0_kernel(size0, size1, work_group_size):
     global_size = math.ceil(size1 / work_group_size) * work_group_size
 
-    # NB: inplace. # Optimized for C-contiguous array and for
+    # NB: the left operand is modified inplace, the right operand is only read into.
+    # Optimized for C-contiguous array and for
     # size1 >> preferred_work_group_size_multiple
     @dpex.kernel
     def broadcast_division(dividend_array, divisor_vector):
@@ -106,12 +107,14 @@ def make_broadcast_ops_1d_2d_axis1_kernel(size0, size1, ops, work_group_size):
     ops must be a function that will be interpreted as a dpex.func and is subject to
     the same rules. It is expected to take two scalar arguments and return one scalar
     value. lambda functions are advised against since the cache will not work with lamda
-    functions."""
+    functions. sklearn_numba_dpex.common._utils expose some pre-defined `ops`.
+    """
 
     global_size = math.ceil(size1 / work_group_size) * work_group_size
     ops = dpex.func(ops)
 
-    # NB: inplace. # Optimized for C-contiguous array and for
+    # NB: the left operand is modified inplace, the right operand is only read into.
+    # Optimized for C-contiguous array and for
     # size1 >> preferred_work_group_size_multiple
     @dpex.kernel
     def broadcast_ops(left_operand_array, right_operand_vector):
@@ -336,7 +339,8 @@ def make_sum_reduction_2d_axis1_kernel(
     It must be a function that will be interpreted as a dpex.func and is subject to the
     same rules. It is expected to take one scalar argument and returning one scalar
     value. lambda functions are advised against since the cache will not work with
-    lambda functions.
+    lambda functions. sklearn_numba_dpex.common._utils expose some pre-defined
+    `fused_unary_funcs`.
 
     Notes
     -----

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -14,7 +14,8 @@ from sklearn_numba_dpex.common.random import (
 from sklearn_numba_dpex.common.kernels import (
     make_initialize_to_zeros_2d_kernel,
     make_initialize_to_zeros_3d_kernel,
-    make_broadcast_division_1d_2d_kernel,
+    make_broadcast_division_1d_2d_axis0_kernel,
+    make_broadcast_ops_1d_2d_axis1_kernel,
     make_half_l2_norm_2d_axis0_kernel,
     make_sum_reduction_2d_axis1_kernel,
     make_argmin_reduction_1d_kernel,
@@ -100,7 +101,7 @@ def lloyd(
         dtype=compute_dtype,
     )
 
-    broadcast_division_kernel = make_broadcast_division_1d_2d_kernel(
+    broadcast_division_kernel = make_broadcast_division_1d_2d_axis0_kernel(
         size0=n_features,
         size1=n_clusters,
         work_group_size=max_work_group_size,
@@ -324,7 +325,77 @@ def lloyd(
     # inertia is now a 1-sized numpy array, we transform it into a scalar:
     inertia = inertia[0]
 
-    return assignments_idx, inertia, centroids_t.T, n_iteration
+    return assignments_idx, inertia, centroids_t, n_iteration
+
+
+def prepare_data_for_lloyd(X_t, init, tol, copy_x):
+    n_features, n_samples = X_t.shape
+    compute_dtype = X_t.dtype.type
+
+    device = X_t.device.sycl_device
+    max_work_group_size = device.max_work_group_size
+
+    sum_axis1_kernel = make_sum_reduction_2d_axis1_kernel(
+        X_t.shape[0],
+        X_t.shape[1],
+        device.max_work_group_size,
+        device=device,
+        dtype=compute_dtype,
+    )
+
+    X_mean = (sum_axis1_kernel(X_t) / compute_dtype(n_samples))[:, 0]
+
+    if (X_mean == 0).astype(int).sum() == len(X_mean):
+        X_mean = None
+    else:
+        X_t = dpt.asarray(X_t, copy=copy_x)
+        broadcast_X_minus_X_mean = make_broadcast_ops_1d_2d_axis1_kernel(
+            n_features,
+            n_samples,
+            ops="minus",
+            work_group_size=max_work_group_size,
+        )
+
+        broadcast_X_minus_X_mean(X_t, X_mean)
+
+        if isinstance(init, dpt.usm_ndarray):
+            n_clusters = init.shape[1]
+            broadcast_init_minus_X_mean = make_broadcast_ops_1d_2d_axis1_kernel(
+                n_features,
+                n_clusters,
+                ops="minus",
+                work_group_size=max_work_group_size,
+            )
+            broadcast_init_minus_X_mean(init, X_mean)
+
+    variance_kernel = make_sum_reduction_2d_axis1_kernel(
+        n_features * n_samples,
+        None,
+        max_work_group_size,
+        device=device,
+        dtype=compute_dtype,
+        fused_unary_func=lambda x: x * x,
+    )
+    variance = variance_kernel(dpt.reshape(X_t, -1)) / n_features
+    tol = variance * tol
+
+    return X_t, X_mean, init, tol
+
+
+def restore_data_after_lloyd(X_t, X_mean):
+    n_features, n_samples = X_t.shape
+
+    device = X_t.device.sycl_device
+    max_work_group_size = device.max_work_group_size
+
+    X_t = dpt.asarray(X_t, copy=False)
+    broadcast_X_plus_X_mean = make_broadcast_ops_1d_2d_axis1_kernel(
+        n_features,
+        n_samples,
+        ops="plus",
+        work_group_size=max_work_group_size,
+    )
+    broadcast_X_plus_X_mean(X_t, X_mean)
 
 
 def _relocate_empty_clusters(
@@ -663,4 +734,4 @@ def kmeans_plusplus(
         centers_t[:, c] = X_t[:, center_index]
         center_indices[c] = center_index
 
-    return centers_t.T, center_indices
+    return centers_t, center_indices

--- a/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
+++ b/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
@@ -343,8 +343,8 @@ def test_kmeans_plusplus_same_quality(dtype):
         kmeans.set_params(random_state=random_state)
         engine = KMeansEngine(kmeans)
         X_prepared, *_ = engine.prepare_fit(X)
-        engine_kmeans_plusplus_centers = engine.init_centroids(X_prepared)
-        engine_kmeans_plusplus_centers = dpt.asnumpy(engine_kmeans_plusplus_centers.T)
+        engine_kmeans_plusplus_centers_t = engine.init_centroids(X_prepared)
+        engine_kmeans_plusplus_centers = dpt.asnumpy(engine_kmeans_plusplus_centers_t.T)
         engine.unshift_centers(X_prepared, engine_kmeans_plusplus_centers)
         scores_engine_kmeans_plusplus.append(
             _get_score_with_centers(engine_kmeans_plusplus_centers)
@@ -398,8 +398,8 @@ def test_kmeans_plusplus_output(array_constr, dtype):
     engine = KMeansEngine(estimator)
     X_prepared, *_ = engine.prepare_fit(X, sample_weight=sample_weight)
 
-    centers, indices = engine._kmeans_plusplus(X_prepared)
-    centers = dpt.asnumpy(centers.T)
+    centers_t, indices = engine._kmeans_plusplus(X_prepared)
+    centers = dpt.asnumpy(centers_t.T)
     engine.unshift_centers(X_prepared, centers)
     indices = dpt.asnumpy(indices)
 

--- a/sklearn_numba_dpex/testing/config.py
+++ b/sklearn_numba_dpex/testing/config.py
@@ -31,14 +31,15 @@ def override_attr_context(obj, **attrs):
     overriden. The initial values are restored when exiting the context.
 
     Trying to override attributes that don't exist will result in an AttributeError"""
+    try:
+        attrs_before = dict()
+        for attr_name, attr_value in attrs.items():
+            # raise AttributeError if obj does not have the attribute attr_name
+            attrs_before[attr_name] = getattr(obj, attr_name)
+            setattr(obj, attr_name, attr_value)
 
-    attrs_before = dict()
-    for attr_name, attr_value in attrs.items():
-        # raise AttributeError if obj does not have the attribute attr_name
-        attrs_before[attr_name] = getattr(obj, attr_name)
-        setattr(obj, attr_name, attr_value)
+        yield
 
-    yield
-
-    for attr_name, attr_value in attrs_before.items():
-        setattr(obj, attr_name, attr_value)
+    finally:
+        for attr_name, attr_value in attrs_before.items():
+            setattr(obj, attr_name, attr_value)


### PR DESCRIPTION
I think I'm happy with the result, the code is a little messy but not more than sklearn's and I think the PR basically succeeds in mimicking almost all aspects of sklearn's UX regarding what inputs are accepted and how it's casted under the hood, and also performance regarding the cautiousness with memory copies, while additionally creating support for `dpnp.ndarray` and `dpt.usm_ndarray` inputs, and recycling the most possible code that already exists in sklearn.

The PR still needs some polishing, and a few tests with `dpnp`/`dpt` tensors.

I think one (minor) difference is that, while sklearn try to convert numpy arrays with `object` dtype to `float64`, our engine will error out in this case because `dpt.asarray` refuses object dtype as input. Those kind of edge cases are complicated to unifiy because different array libraries can have different choices and I think it's fine we let it fail in this case.