### PR TITLE
FIX: Prepare for dpnp 0.11.0

### DIFF
--- a/sklearn_numba_dpex/common/_utils.py
+++ b/sklearn_numba_dpex/common/_utils.py
@@ -17,3 +17,7 @@ def _minus(x, y):
 
 def _plus(x, y):
     return x + y
+
+
+def _divide(x, y):
+    return x / y

--- a/sklearn_numba_dpex/common/kernels.py
+++ b/sklearn_numba_dpex/common/kernels.py
@@ -30,6 +30,25 @@ zero_idx = np.int64(0)
 
 
 @lru_cache
+def make_elementwise_binary_ops_1d_kernel(size, ops, work_group_size):
+
+    ops = dpex.func(ops)
+
+    @dpex.kernel
+    def elementwise_ops(data, operand_right):
+
+        item_idx = dpex.get_global_id(zero_idx)
+        if item_idx >= size:
+            return
+
+        operand_left = data[item_idx]
+        data[item_idx] = ops(operand_left, operand_right[0])
+
+    global_size = math.ceil(size / work_group_size) * work_group_size
+    return elementwise_ops[global_size, work_group_size]
+
+
+@lru_cache
 def make_initialize_to_zeros_2d_kernel(size0, size1, work_group_size, dtype):
 
     n_items = size0 * size1
@@ -240,6 +259,9 @@ def make_sum_reduction_2d_axis1_kernel(
 
     def sum_reduction(summands):
         # TODO: manually dispatch the kernels with a SyclQueue
+        if not kernels_and_empty_tensors_pairs:
+            return dpt.zeros(sh=(1,), device=device, dtype=dtype)
+
         for kernel, result in kernels_and_empty_tensors_pairs:
             kernel(summands, result)
             summands = result


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/soda-inria/sklearn-numba-dpex/pull/68

Before  `dpnp==0.11.0` (NB: our current image uses `0.11.0rc1`) some calls to `dpnp` could silently fallback on `numpy`. [From `0.11.0` on](https://github.com/IntelPython/dpnp/pull/1201) the silent fallback is removed and an error is raised instead (the fallback mode can be reactivated with an environment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK`).

That breaks our code at several locations:
- direct call to `take` triggers a fallback
- broadcasting binary operations [triggers fallbacks](https://github.com/IntelPython/dpnp/issues/1238) (!!) 

I'm worried that silent fallbacks on numpy when running on gpu could have dramatic effects on performance if it could trigger memory transfers. Rather than setting this environment variable to reactivate the fallbacks I'd prefer fixing the code so that fallbacks are not needed anymore.

The fixes do not affect parts of the code that are critical for performance so the benchmarks are not affected (luckily or not I wonder :grin: )