### PR TITLE
Compute new_centroid_t before computing value of current inertia in verbose mode

### DIFF
--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -204,7 +204,7 @@ def lloyd(
             empty_clusters_list,
             n_empty_clusters,
         )
-        
+
         if verbose:
             # ???: verbosity comes at the cost of performance since it triggers
             # computing exact inertia at each iteration. Shouldn't this be


### PR DESCRIPTION
If `verbose` is set, computing current value of inertial requires `new_centroid_t` to be available. 

Hence `reduce_centroid_data_kernel` must be executed before we check `verbose` flag.

@fcharras 
