### PR TITLE
Add kmeans_dpcpp to benchmark

### DIFF
--- a/benchmark/ext_helpers/kmeans_dpcpp.py
+++ b/benchmark/ext_helpers/kmeans_dpcpp.py
@@ -1,0 +1,46 @@
+import dpctl.tensor as dpt
+import kmeans_dpcpp as kdp
+
+from sklearn.exceptions import NotSupportedByEngineError
+from sklearn_numba_dpex.kmeans.engine import KMeansEngine
+
+
+class KMeansDPCPPEngine(KMeansEngine):
+    def init_centroids(self, X):
+        init = self.init
+        if isinstance(init, str) and init == "k-means++":
+            raise NotSupportedByEngineError(
+                "kmeans_dpcpp does not support k-means++ init."
+            )
+        return super().init_centroids(X)
+
+    def kmeans_single(self, X, sample_weight, centers_init_t):
+        n_samples, n_features = X.shape
+        device = X.device.sycl_device
+
+        assignments_idx = dpt.empty(n_samples, dtype=dpt.int32, device=device)
+        res_centroids_t = dpt.empty_like(centers_init_t)
+
+        # TODO: make work_group_size and centroid window dimension consistent in
+        # kmeans_dpcpp with up to date configuration in sklearn_numba_dpex
+        centroids_window_height = 8
+        work_group_size = 128
+
+        centroids_private_copies_max_cache_occupancy = 0.7
+
+        n_iters, total_inertia = kdp.kmeans_lloyd_driver(
+            X.T,
+            sample_weight,
+            centers_init_t,
+            assignments_idx,
+            res_centroids_t,
+            self.tol,
+            bool(self.estimator.verbose),
+            self.estimator.max_iter,
+            centroids_window_height,
+            work_group_size,
+            centroids_private_copies_max_cache_occupancy,
+            X.sycl_queue,
+        )
+
+        return assignments_idx, total_inertia, res_centroids_t, n_iters


### PR DESCRIPTION
Benchmark results:

```
Running Sklearn vanilla lloyd with parameters sample_weight=unary n_clusters=127 data_shape=(263256, 14) max_iter=100...
Running Sklearn vanilla lloyd ... done in 1.3 s

Running kmeans_dpcpp lloyd GPU with parameters sample_weight=unary n_clusters=127 data_shape=(263256, 14) max_iter=100...
/sklearn-numba-dpex/benchmark/./kmeans.py:108: ConvergenceWarning: Number of distinct clusters (32) found smaller than n_clusters (127). Possibly due to duplicate points in X.
  KMeans(**est_kwargs).set_params(max_iter=1).fit(
/sklearn-numba-dpex/benchmark/./kmeans.py:116: ConvergenceWarning: Number of distinct clusters (28) found smaller than n_clusters (127). Possibly due to duplicate points in X.
  estimator.fit(X, sample_weight=sample_weight)
Running kmeans_dpcpp lloyd GPU ... done in 1.2 s

Running Kmeans numba_dpex lloyd GPU with parameters sample_weight=unary n_clusters=127 data_shape=(263256, 14) max_iter=100...
Running Kmeans numba_dpex lloyd GPU ... done in 0.7 s
```

- `kmeans_dpcpp` runs but do not return good results. (the warning 

```
/sklearn-numba-dpex/benchmark/./kmeans.py:108: ConvergenceWarning: Number of distinct clusters (32) found smaller than n_clusters (127). Possibly due to duplicate points in X.
```
  usually hints that the output is random)

- our `numba_dpex` implementation is faster (NB: the benchmark ignore JIT overhead) but maybe `work_group_size` and `centroids_window_height` must be tinkered for `kmeans_dpcpp`. Also I think `kmeans_dpcpp` implements a version that we had before https://github.com/soda-inria/sklearn-numba-dpex/pull/51 and https://github.com/soda-inria/sklearn-numba-dpex/pull/49, that changed the heuristic used to choose the window over centroids, and improved performance noticeably while pruning the code overall. I'd recommend copying this heuristic from `main`. `main` for `KMeans` has stabilized and we don't have plan to change it as much as it was being rewritten at the time (sorry for that).  

**Unrelated**: apparently, `scikit-learn-intelex` bump to `2023` broke the benchmarks `sklearnex`. There are also issues with the docker image that has been automatically built yesterday night, since then our test pipeline [doesn't pass on main](https://github.com/soda-inria/sklearn-numba-dpex). I'm gonna look into those issues. In the meantime I think the docker image at `jjerphan/numba_dpex_dev` is broken, the conda install suggested in the README should be preferred.

edit: fixed all unrelated things and rebased, the benchmark can now be tested in stable conditions :pray: 