### PR TITLE
Temporarily pin dpcpp runtime in conda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ conda create --yes --name $CONDA_DPEX_ENV_NAME \
              --channel dppy/label/dev \
              --channel conda-forge \
              --channel intel \
+             # TODO: remove <2023.0.0 pin after dppy/label/dev is updated
              numba-dpex "intel::dpcpp_linux-64<2023.0.0"
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ conda create --yes --name $CONDA_DPEX_ENV_NAME \
              --channel dppy/label/dev \
              --channel conda-forge \
              --channel intel \
-             numba-dpex intel::dpcpp_linux-64
+             numba-dpex "intel::dpcpp_linux-64<2023.0.0"
 ```
 
 (where you can replace the name of the environment `my-dpex-env` with a name of your

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ conda create --yes --name $CONDA_DPEX_ENV_NAME \
              --channel conda-forge \
              --channel intel \
              `# TODO: remove <2023.0.0 pin after dppy/label/dev is updated` \
+             `# see https://github.com/IntelPython/dpctl/issues/1022` \
              numba-dpex "intel::dpcpp_linux-64<2023.0.0"
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ conda create --yes --name $CONDA_DPEX_ENV_NAME \
              --channel dppy/label/dev \
              --channel conda-forge \
              --channel intel \
-             # TODO: remove <2023.0.0 pin after dppy/label/dev is updated
+             `# TODO: remove <2023.0.0 pin after dppy/label/dev is updated` \
              numba-dpex "intel::dpcpp_linux-64<2023.0.0"
 ```
 


### PR DESCRIPTION
To be reverted when https://github.com/IntelPython/dpctl/issues/1022 is closed