### PR TITLE
Fix a bug that caused some kmeans helper kernels to not be correctly cached

### DIFF
--- a/benchmark/ext_helpers/kmeans_dpcpp.py
+++ b/benchmark/ext_helpers/kmeans_dpcpp.py
@@ -1,0 +1,46 @@
+import dpctl.tensor as dpt
+import kmeans_dpcpp as kdp
+
+from sklearn.exceptions import NotSupportedByEngineError
+from sklearn_numba_dpex.kmeans.engine import KMeansEngine
+
+
+class KMeansDPCPPEngine(KMeansEngine):
+    def init_centroids(self, X):
+        init = self.init
+        if isinstance(init, str) and init == "k-means++":
+            raise NotSupportedByEngineError(
+                "kmeans_dpcpp does not support k-means++ init."
+            )
+        return super().init_centroids(X)
+
+    def kmeans_single(self, X, sample_weight, centers_init_t):
+        n_samples, n_features = X.shape
+        device = X.device.sycl_device
+
+        assignments_idx = dpt.empty(n_samples, dtype=dpt.int32, device=device)
+        res_centroids_t = dpt.empty_like(centers_init_t)
+
+        # TODO: make work_group_size and centroid window dimension consistent in
+        # kmeans_dpcpp with up to date configuration in sklearn_numba_dpex
+        centroids_window_height = 8
+        work_group_size = 128
+
+        centroids_private_copies_max_cache_occupancy = 0.7
+
+        n_iters, total_inertia = kdp.kmeans_lloyd_driver(
+            X.T,
+            sample_weight,
+            centers_init_t,
+            assignments_idx,
+            res_centroids_t,
+            self.tol,
+            bool(self.estimator.verbose),
+            self.estimator.max_iter,
+            centroids_window_height,
+            work_group_size,
+            centroids_private_copies_max_cache_occupancy,
+            X.sycl_queue,
+        )
+
+        return assignments_idx, total_inertia, res_centroids_t, n_iters

--- a/benchmark/kmeans.py
+++ b/benchmark/kmeans.py
@@ -160,6 +160,8 @@ class KMeansLloydTimeit:
 
 
 if __name__ == "__main__":
+    import warnings
+
     from numpy.random import default_rng
     from sklearn.datasets import fetch_openml
     from sklearn.preprocessing import MinMaxScaler
@@ -168,14 +170,11 @@ if __name__ == "__main__":
     import sklearn_numba_dpex.kmeans.engine as skdpex_kmeans_engine_module
     from sklearn_numba_dpex.kmeans.engine import KMeansEngine
 
-    from ext_helpers.daal4py import DAAL4PYEngine
-    from sklearnex import config_context as sklearnex_config_context
-
     # TODO: expose CLI args.
 
     random_state = 123
     sample_weight = "unary"  # None, "unary", or "random"
-    init = "k-means++"  # "k-means++" or "random"
+    init = "random"  # "k-means++" or "random"
     n_clusters = 127
     max_iter = 100
     skip_slow = True
@@ -226,21 +225,54 @@ if __name__ == "__main__":
         name="Sklearn vanilla lloyd",
     )
 
-    with override_attr_context(
-        skdpex_kmeans_engine_module, KMeansEngine=DAAL4PYEngine
-    ), sklearnex_config_context(target_offload="cpu"):
-        kmeans_timer.timeit(
-            name="daal4py lloyd CPU", engine_provider="sklearn_numba_dpex"
+    try:
+        from sklearnex import config_context as sklearnex_config_context
+        from ext_helpers.daal4py import DAAL4PYEngine
+    except ModuleNotFoundError:
+        warnings.warn(
+            "scikit-learn-intelex can't be found. Benchmark will be skipped.",
+            RuntimeWarning,
         )
+    else:
+        with override_attr_context(
+            skdpex_kmeans_engine_module, KMeansEngine=DAAL4PYEngine
+        ), sklearnex_config_context(target_offload="cpu"):
+            kmeans_timer.timeit(
+                name="daal4py lloyd CPU", engine_provider="sklearn_numba_dpex"
+            )
 
-    with override_attr_context(
-        skdpex_kmeans_engine_module, KMeansEngine=DAAL4PYEngine
-    ), sklearnex_config_context(target_offload="gpu"):
-        kmeans_timer.timeit(
-            name="daal4py lloyd GPU",
-            engine_provider="sklearn_numba_dpex",
-            is_slow=True,
+        with override_attr_context(
+            skdpex_kmeans_engine_module, KMeansEngine=DAAL4PYEngine
+        ), sklearnex_config_context(target_offload="gpu"):
+            kmeans_timer.timeit(
+                name="daal4py lloyd GPU",
+                engine_provider="sklearn_numba_dpex",
+                is_slow=True,
+            )
+
+    try:
+        from ext_helpers.kmeans_dpcpp import KMeansDPCPPEngine
+    except ImportError:
+        warnings.warn(
+            "kmeans_dpcpp can't be found. Benchmark will be skipped.", RuntimeWarning
         )
+    else:
+        with override_attr_context(
+            skdpex_kmeans_engine_module, KMeansEngine=KMeansDPCPPEngine
+        ), override_attr_context(KMeansDPCPPEngine, _CONFIG=dict(device="cpu")):
+            kmeans_timer.timeit(
+                name="kmeans_dpcpp lloyd CPU",
+                engine_provider="sklearn_numba_dpex",
+                is_slow=True,
+            )
+
+        with override_attr_context(
+            skdpex_kmeans_engine_module, KMeansEngine=KMeansDPCPPEngine
+        ), override_attr_context(KMeansDPCPPEngine, _CONFIG=dict(device="gpu")):
+            kmeans_timer.timeit(
+                name="kmeans_dpcpp lloyd GPU",
+                engine_provider="sklearn_numba_dpex",
+            )
 
     with override_attr_context(KMeansEngine, _CONFIG=dict(device="cpu")):
         kmeans_timer.timeit(

--- a/sklearn_numba_dpex/common/kernels.py
+++ b/sklearn_numba_dpex/common/kernels.py
@@ -32,6 +32,13 @@ from sklearn_numba_dpex.common._utils import (
 zero_idx = np.int64(0)
 
 
+# HACK: make_* functions that take an operator as input (named `op`, `ops`,
+# `fused_unary_func`,...) now expect those operators to be wrapped in another function
+# that takes no arguments and returns the said operator. See the notice in the
+# `sklearn_numba_dpex.common._utils` where some operators are pre-defined for more
+# information.
+
+
 # HACK: dtype argument is passed to prevent sharing a device function instance
 # between kernels specialized for different argument types.
 # This is a workaround for:
@@ -42,7 +49,7 @@ zero_idx = np.int64(0)
 def make_elementwise_binary_op_1d_kernel(size, op, work_group_size, dtype):
     """This kernel is mostly necessary to work around lack of support for this
     operation in dpnp, see https://github.com/IntelPython/dpnp/issues/1238"""
-    op = dpex.func(op)
+    op = dpex.func(op())
 
     @dpex.kernel
     # fmt: off
@@ -144,7 +151,7 @@ def make_broadcast_ops_1d_2d_axis1_kernel(size0, size1, ops, work_group_size, dt
     """
 
     global_size = math.ceil(size1 / work_group_size) * work_group_size
-    ops = dpex.func(ops)
+    ops = dpex.func(ops())
 
     # NB: the left operand is modified inplace, the right operand is only read into.
     # Optimized for C-contiguous array and for
@@ -312,10 +319,12 @@ def _make_partial_sum_reduction_2d_axis1_kernel(
 
     if fused_unary_func is None:
 
-        def fused_unary_func(x):
+        @dpex.func
+        def fused_unary_func_(x):
             return x
 
-    fused_unary_func_ = dpex.func(fused_unary_func)
+    else:
+        fused_unary_func_ = dpex.func(fused_unary_func())
 
     input_work_group_size = work_group_size
     work_group_size = _check_max_work_group_size(

--- a/sklearn_numba_dpex/common/random.py
+++ b/sklearn_numba_dpex/common/random.py
@@ -158,39 +158,46 @@ def create_xoroshiro128pp_states(n_states, subsequence_start=0, seed=None, devic
     if hasattr(seed, "randint"):
         seed = uint64(seed.randint(0, np.iinfo(np.int64).max - 1))
 
-    seed = uint64(seed)
+    init_xoroshiro128pp_states_kernel = _make_init_xoroshiro128pp_states_kernel(
+        n_states, subsequence_start
+    )
+
+    # Initialization is purely sequential so it will be faster on CPU, if a cpu device
+    # is available make sure to use it.
+    if device is None:
+        device = dpctl.SyclDevice()
+    from_cpu_to_device = False
+    if not device.has_aspect_cpu:
+        try:
+            cpu_device = dpctl.SyclDevice("cpu")
+            from_cpu_to_device = True
+        except dpctl.SyclDeviceCreationError:
+            warnings.warn(
+                "No CPU found, falling back random initiatlization to default device."
+            )
+
+    states = dpt.empty(
+        sh=(n_states, 2),
+        dtype=np.uint64,
+        device=cpu_device if from_cpu_to_device else device,
+    )
+
+    seed = dpt.asarray(
+        [seed], dtype=np.uint64, device=cpu_device if from_cpu_to_device else device
+    )
+
+    init_xoroshiro128pp_states_kernel(states, seed)
+
+    if from_cpu_to_device:
+        return states.to_device(device)
+
+    else:
+        return states
+
+
+@lru_cache
+def _make_init_xoroshiro128pp_states_kernel(n_states, subsequence_start):
     n_states = int64(n_states)
-
-    init_const_1 = np.uint64(0)
-
-    @dpex.kernel
-    def init_xoroshiro128pp_states(states):
-        """
-        Use SplitMix64 to generate an xoroshiro128p state from a uint64 seed.
-
-        This ensures that manually set small seeds don't result in a predictable
-        initial sequence from the random number generator.
-        """
-        if n_states < one_idx:
-            return
-
-        splitmix64_state = init_const_1 ^ seed
-        splitmix64_state, states[zero_idx, zero_idx] = _splitmix64_next(
-            splitmix64_state
-        )
-        _, states[zero_idx, one_idx] = _splitmix64_next(splitmix64_state)
-
-        # advance to starting subsequence number
-        for _ in range(subsequence_start):
-            _xoroshiro128pp_jump(states, zero_idx)
-
-        # populate the rest of the array
-        for idx in range(one_idx, n_states):
-            # take state of previous generator
-            states[idx, zero_idx] = states[idx - one_idx, zero_idx]
-            states[idx, one_idx] = states[idx - one_idx, one_idx]
-            # and jump forward 2**64 steps
-            _xoroshiro128pp_jump(states, idx)
 
     splitmix64_const_1 = uint64(0x9E3779B97F4A7C15)
     splitmix64_const_2 = uint64(0xBF58476D1CE4E5B9)
@@ -234,6 +241,8 @@ def create_xoroshiro128pp_states(n_states, subsequence_start=0, seed=None, devic
 
         states[state_idx, zero_idx] = s0
         states[state_idx, one_idx] = s1
+
+    init_const_1 = np.uint64(0)
 
     # TODO: it seems that the reference python implementation in the package
     # `randomgen` that inspired this code contains errors.
@@ -292,32 +301,36 @@ def create_xoroshiro128pp_states(n_states, subsequence_start=0, seed=None, devic
 
     #     return result
 
-    # Initialization is purely sequential so it will be faster on CPU, if a cpu device
-    # is available make sure to use it.
-    if device is None:
-        device = dpctl.SyclDevice()
-    from_cpu_to_device = False
-    if not device.has_aspect_cpu:
-        try:
-            cpu_device = dpctl.SyclDevice("cpu")
-            from_cpu_to_device = True
-        except dpctl.SyclDeviceCreationError:
-            warnings.warn(
-                "No CPU found, falling back random initiatlization to default device."
-            )
+    @dpex.kernel
+    def init_xoroshiro128pp_states(states, seed):
+        """
+        Use SplitMix64 to generate an xoroshiro128p state from a uint64 seed.
 
-    states = dpt.empty(
-        sh=(n_states, 2),
-        dtype=np.uint64,
-        device=cpu_device if from_cpu_to_device else device,
-    )
-    init_xoroshiro128pp_states[1, 1](states)
+        This ensures that manually set small seeds don't result in a predictable
+        initial sequence from the random number generator.
+        """
+        if n_states < one_idx:
+            return
 
-    if from_cpu_to_device:
-        return states.to_device(device)
+        splitmix64_state = init_const_1 ^ seed[zero_idx]
+        splitmix64_state, states[zero_idx, zero_idx] = _splitmix64_next(
+            splitmix64_state
+        )
+        _, states[zero_idx, one_idx] = _splitmix64_next(splitmix64_state)
 
-    else:
-        return states
+        # advance to starting subsequence number
+        for _ in range(subsequence_start):
+            _xoroshiro128pp_jump(states, zero_idx)
+
+        # populate the rest of the array
+        for idx in range(one_idx, n_states):
+            # take state of previous generator
+            states[idx, zero_idx] = states[idx - one_idx, zero_idx]
+            states[idx, one_idx] = states[idx - one_idx, one_idx]
+            # and jump forward 2**64 steps
+            _xoroshiro128pp_jump(states, idx)
+
+    return init_xoroshiro128pp_states[1, 1]
 
 
 # HACK: Work around https://github.com/IntelPython/numba-dpex/issues/867

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -6,9 +6,6 @@ import dpctl.tensor as dpt
 import dpnp
 import numpy as np
 
-# HACK: temporarily, those operators are wrapped in a function that must be called
-# without arguments to get the operator.
-# See the notice where they are defined for more information.
 from sklearn_numba_dpex.common._utils import _divide, _minus, _plus, _square
 from sklearn_numba_dpex.common.kernels import (
     make_argmin_reduction_1d_kernel,
@@ -468,7 +465,7 @@ def prepare_data_for_lloyd(X_t, init, tol, sample_weight, copy_x):
     )
 
     elementwise_binary_divide_kernel = make_elementwise_binary_op_1d_kernel(
-        n_features, _divide(), max_work_group_size, compute_dtype
+        n_features, _divide, max_work_group_size, compute_dtype
     )
 
     # At the time of writing this code, dpnp does not support functions (like `==`
@@ -481,7 +478,7 @@ def prepare_data_for_lloyd(X_t, init, tol, sample_weight, copy_x):
         work_group_size="max",
         device=device,
         dtype=compute_dtype,
-        fused_unary_func=_square(),
+        fused_unary_func=_square,
     )
 
     X_mean = sum_axis1_kernel(X_t)[:, 0]
@@ -507,7 +504,7 @@ def prepare_data_for_lloyd(X_t, init, tol, sample_weight, copy_x):
         broadcast_X_minus_X_mean = make_broadcast_ops_1d_2d_axis1_kernel(
             n_features,
             n_samples,
-            ops=_minus(),
+            ops=_minus,
             work_group_size=max_work_group_size,
             dtype=compute_dtype,
         )
@@ -520,7 +517,7 @@ def prepare_data_for_lloyd(X_t, init, tol, sample_weight, copy_x):
             broadcast_init_minus_X_mean = make_broadcast_ops_1d_2d_axis1_kernel(
                 n_features,
                 n_clusters,
-                ops=_minus(),
+                ops=_minus,
                 work_group_size=max_work_group_size,
                 dtype=compute_dtype,
             )
@@ -535,7 +532,7 @@ def prepare_data_for_lloyd(X_t, init, tol, sample_weight, copy_x):
         work_group_size="max",
         device=device,
         dtype=compute_dtype,
-        fused_unary_func=_square(),
+        fused_unary_func=_square,
     )
 
     variance = variance_kernel(dpt.reshape(X_t, -1))
@@ -582,7 +579,7 @@ def restore_data_after_lloyd(X_t, best_centers_t, X_mean, copy_x):
     broadcast_init_plus_X_mean = make_broadcast_ops_1d_2d_axis1_kernel(
         n_features,
         n_clusters,
-        ops=_plus(),
+        ops=_plus,
         work_group_size=max_work_group_size,
         dtype=compute_dtype,
     )
@@ -604,7 +601,7 @@ def restore_data_after_lloyd(X_t, best_centers_t, X_mean, copy_x):
         broadcast_X_plus_X_mean = make_broadcast_ops_1d_2d_axis1_kernel(
             n_features,
             n_samples,
-            ops=_plus(),
+            ops=_plus,
             work_group_size=max_work_group_size,
             dtype=compute_dtype,
         )


### PR DESCRIPTION
Revert some changes in one of the last cleaning commits in  https://github.com/soda-inria/sklearn-numba-dpex/pull/82 Those changes disrupted the caching of some kernels, causing re-compiling at each iteration in kmeans, with a big performance hit.

Also improves the performance of kmeans++ since there were an even older issue with caching in the random module. 

This issue also teach us that bugs in caching can be disastrous and are totally silent and should always require special care.