### PR TITLE
Fix issues seen on devcloud with flex170 gpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ conda create --yes --name $CONDA_DPEX_ENV_NAME \
              --channel dppy/label/dev \
              --channel conda-forge \
              --channel intel \
-             # NB: different versions of `sklearn_numba_dpex` can require to pin
-             # different versions, build or channels here.
+             `# NB: different versions of `sklearn_numba_dpex` can require to pin` \
+             `# different versions, builds or channels here.` \
              numba-dpex=0.19.0=py39hfc4b9b4_5 "intel::dpcpp_linux-64"
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ conda create --yes --name $CONDA_DPEX_ENV_NAME \
              --channel dppy/label/dev \
              --channel conda-forge \
              --channel intel \
-             `# TODO: remove <2023.0.0 pin after dppy/label/dev is updated` \
-             `# see https://github.com/IntelPython/dpctl/issues/1022` \
-             numba-dpex "intel::dpcpp_linux-64"
+             # NB: different versions of `sklearn_numba_dpex` can require to pin
+             # different versions, build or channels here.
+             numba-dpex=0.19.0=py39hfc4b9b4_5 "intel::dpcpp_linux-64"
 ```
 
 (where you can replace the name of the environment `my-dpex-env` with a name of your

--- a/sklearn_numba_dpex/common/_utils.py
+++ b/sklearn_numba_dpex/common/_utils.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 
 def check_power_of_2(e):
@@ -88,3 +89,25 @@ def _check_max_work_group_size(
         )
     else:
         return work_group_size
+
+
+_GLOBAL_MEM_CACHE_SIZE_DEFAULT = 1048576
+
+
+# Work around https://github.com/IntelPython/dpctl/issues/1036
+def _get_global_mem_cache_size(device):
+    if (global_mem_cache_size := device.global_mem_cache_size) > 0:
+        return global_mem_cache_size
+
+    warnings.warn(
+        "Can't inspect the available global memory cache size for the device "
+        f"{device.name}. Please check that your drivers and runtime libraries are up "
+        "to date, if this warning persists please report it at "
+        "https://github.com/soda-inria/sklearn-numba-dpex/issues . The execution will "
+        "continue with a default value for the cache size set to "
+        f"{_GLOBAL_MEM_CACHE_SIZE_DEFAULT} , which is assumed to be safe but might "
+        "not be adapted to your device and cause a loss of performance.",
+        RuntimeWarning,
+    )
+
+    return _GLOBAL_MEM_CACHE_SIZE_DEFAULT

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -6,7 +6,13 @@ import dpctl.tensor as dpt
 import dpnp
 import numpy as np
 
-from sklearn_numba_dpex.common._utils import _divide, _minus, _plus, _square
+from sklearn_numba_dpex.common._utils import (
+    _divide,
+    _get_global_mem_cache_size,
+    _minus,
+    _plus,
+    _square,
+)
 from sklearn_numba_dpex.common.kernels import (
     make_argmin_reduction_1d_kernel,
     make_broadcast_division_1d_2d_axis0_kernel,
@@ -54,7 +60,7 @@ def lloyd(
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
     sub_group_size = min(device.sub_group_sizes)
-    global_mem_cache_size = device.global_mem_cache_size
+    global_mem_cache_size = _get_global_mem_cache_size(device)
     centroids_private_copies_max_cache_occupancy = 0.7
 
     verbose = bool(verbose)

--- a/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
@@ -20,17 +20,17 @@ def make_label_assignment_fixed_window_kernel(
     n_samples, n_features, n_clusters, sub_group_size, work_group_size, dtype, device
 ):
     window_n_centroids = sub_group_size
-    centroids_window_width = window_n_centroids + 1
 
     dtype_itemsize = np.dtype(dtype).itemsize
     input_work_group_size = work_group_size
     work_group_size = _check_max_work_group_size(
         work_group_size,
         device,
-        required_local_memory_per_item=centroids_window_width * dtype_itemsize,
+        required_local_memory_per_item=dtype_itemsize,
         required_memory_constant=sub_group_size * dtype_itemsize,
     )
 
+    centroids_window_width = window_n_centroids
     centroids_window_height = work_group_size // sub_group_size
 
     if work_group_size != input_work_group_size:

--- a/sklearn_numba_dpex/kmeans/kernels/kmeans_plusplus.py
+++ b/sklearn_numba_dpex/kmeans/kernels/kmeans_plusplus.py
@@ -109,16 +109,13 @@ def make_kmeansplusplus_single_step_fixed_window_kernel(
 ):
 
     window_n_candidates = sub_group_size
-    candidates_window_width = window_n_candidates + 1
 
     input_work_group_size = work_group_size
     work_group_size = _check_max_work_group_size(
-        work_group_size,
-        device,
-        required_local_memory_per_item=candidates_window_width
-        * np.dtype(dtype).itemsize,
+        work_group_size, device, required_local_memory_per_item=np.dtype(dtype).itemsize
     )
 
+    candidates_window_width = window_n_candidates
     candidates_window_height = work_group_size // sub_group_size
 
     if work_group_size != input_work_group_size:

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -60,17 +60,17 @@ def make_lloyd_single_step_fixed_window_kernel(
     #     of items is: `centroids_window_height * window_n_centroids`, i.e.
     #     `centroids_window_height * sub_group_size`
     window_n_centroids = sub_group_size
-    centroids_window_width = window_n_centroids + 1
 
     dtype_itemsize = np.dtype(dtype).itemsize
     input_work_group_size = work_group_size
     work_group_size = _check_max_work_group_size(
         work_group_size,
         device,
-        required_local_memory_per_item=centroids_window_width * dtype_itemsize,
+        required_local_memory_per_item=dtype_itemsize,
         required_memory_constant=sub_group_size * dtype_itemsize,
     )
 
+    centroids_window_width = window_n_centroids
     centroids_window_height = work_group_size // sub_group_size
 
     if work_group_size != input_work_group_size:


### PR DESCRIPTION
- pin numba_dpex build from dppy/label/dev conda channel
- use a default hardcoded value when device global memory cache size can't be fetched

For the latter fix it will be interesting to test during the next session on the devcloud if clinfo also fails at finding `global_memory_cache_size`, else we could use `pyopencl`.