### PR TITLE
FIX make test_error_raised_on_invalid_group_sizes pass on smaller GPUs

### DIFF
--- a/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
+++ b/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
@@ -449,7 +449,7 @@ def test_error_raised_on_invalid_group_sizes():
     n_features = 2
     n_clusters = 2
     sub_group_size = 64
-    work_group_size = 500  # invalid because is not a multiple of sub_group_size
+    work_group_size = 200  # invalid because is not a multiple of sub_group_size
     dtype = np.float32
     device = dpctl.SyclDevice()
 


### PR DESCRIPTION
My `max_work_group_size` is 256.

```python
>>> import dpctl
>>> dpctl.SyclDevice()
<dpctl.SyclDevice [backend_type.opencl, device_type.gpu,  Intel(R) Iris(R) Graphics 540 [0x1926]] at 0x7ff4e77fc5f0>
```