### PR TITLE
ENH Use a 2D grid of work items where applicable

### DIFF
--- a/sklearn_numba_dpex/common/__init__.py
+++ b/sklearn_numba_dpex/common/__init__.py
@@ -1,14 +1,7 @@
 # TODO: many auxilliary kernels in this module might be better optimized and we could
-# benchmark alternative implementations for each of them, that could include
-#    - using 2D or 3D grid of work groups and work items where applicable (e.g. in
-# some of the kernels that take 2D or 3D data as input) rather than using 1D grid. When
-# doing so, one should be especially careful about how the segments of adjacent work
-# items of size preferred_work_group_size_multiple are dispatched especially regarding
-# RW  operations in memory. A wrong dispatch strategy could slash memory bandwith and
-# reduce performance. Using 2D or 3D grid correctly might on the other hand improve
-# performance since it saves costly indexing operations (like //)
-#    - using numba + dpnp to directly leverage kernels that are shipped in dpnp to
-# replace numpy methods.
+# benchmark alternative implementations for each of them, that could include using
+# numba + dpnp to directly leverage kernels that are shipped in dpnp to replace numpy
+# methods.
 # However, in light of our main goal that is bringing a GPU KMeans to scikit-learn, the
 # importance of those TODOs is currently seen as secondary, since the execution time of
 # those kernels is only a small fraction of the total execution time and the

--- a/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
+++ b/sklearn_numba_dpex/kmeans/kernels/_base_kmeans_kernel_funcs.py
@@ -1,4 +1,5 @@
 import numba_dpex as dpex
+import numpy as np
 
 
 def make_pairwise_ops_base_kernel_funcs(
@@ -63,7 +64,8 @@ def make_pairwise_ops_base_kernel_funcs(
 
         @dpex.func
         def initialize_window_of_centroids(
-            local_work_id,
+            local_row_idx,
+            local_col_idx,
             first_centroid_idx,
             centroids_half_l2_norm,
             is_last_centroid_window,
@@ -73,7 +75,8 @@ def make_pairwise_ops_base_kernel_funcs(
         ):
             if is_last_centroid_window:
                 initialize_last_window_of_centroids(
-                    local_work_id,
+                    local_row_idx,
+                    local_col_idx,
                     first_centroid_idx,
                     centroids_half_l2_norm,
                     # OUT
@@ -82,7 +85,8 @@ def make_pairwise_ops_base_kernel_funcs(
                 )
             else:
                 initialize_full_window_of_centroids(
-                    local_work_id,
+                    local_row_idx,
+                    local_col_idx,
                     first_centroid_idx,
                     centroids_half_l2_norm,
                     # OUT
@@ -203,6 +207,7 @@ class _KMeansKernelFuncFactory:
 
     def make_initialize_window_kernel_func(self, window_n_centroids):
         zero = self.dtype(0.0)
+        zero_as_a_long = np.int64(0)
 
         @dpex.func
         def _initialize_results(results):
@@ -217,22 +222,36 @@ class _KMeansKernelFuncFactory:
         @dpex.func
         # fmt: off
         def _initialize_window_of_centroids(
-            local_work_id,                      # PARAM
+            local_row_idx,                      # PARAM
+            local_col_idx,                      # PARAM
             first_centroid_idx,                 # PARAM
             centroids_half_l2_norm,             # IN       (self.n_clusters,)
-            window_of_centroids_half_l2_norms,  # OUT      (window_n_centroids,)
-            results,                            # OUT      (window_n_centroids,)
+            window_of_centroids_half_l2_norms,  # OUT      (work_group_shape[0],)
+            results,                            # OUT      (work_group_shape[0],)
         ):
             # fmt: on
             _initialize_results(results)
 
-            # The first `window_n_centroids` work items cooperate on loading the
-            # values of centroids_half_l2_norm relevant to current window. Each work
-            # item loads one single value.
-            if local_work_id < window_n_centroids:
-                half_l2_norm_loading_idx = first_centroid_idx + local_work_id
-                window_of_centroids_half_l2_norms[local_work_id] = (
-                    centroids_half_l2_norm[half_l2_norm_loading_idx]
+            # The work items are indexed in a 2D grid of shape
+            # `work_group_shape = (centroids_window_height, window_n_centroids)`, where
+            # `centroids_window_height` and `window_n_centroids` refer to a window of
+            # centroids that is entirely within the boundaries of the centroid array.
+            # The `window_n_centroids` work items in the first row cooperate on loading
+            # the values of `centroids_half_l2_norm` relevant to current window. Each
+            # work item loads one single value.
+
+            # NB: Close to the boundaries, the value of `window_n_centroids` is
+            # adjusted so that the window fits within the boundaries of the array,
+            # however the shape of the work group does not change. The work items in
+            # the 2D grid such as `local_col_idx` is greater than the actual value of
+            # `window_n_centroids` at the boundaries must be discarded, to avoid
+            # reading unallocated space in global memory.
+            if (
+                (local_row_idx == zero_as_a_long)  # select first row
+                and (local_col_idx < window_n_centroids)  # necessary condition at boundaries  # noqa
+            ):
+                window_of_centroids_half_l2_norms[local_col_idx] = (
+                    centroids_half_l2_norm[first_centroid_idx + local_col_idx]
                 )
 
         return _initialize_window_of_centroids


### PR DESCRIPTION
- [x] Where applicable, use 2D grid of work items rather than 1D + divisions 
    + note: found this piece of information: https://stackoverflow.com/a/15044884 suggesting that:
        + 2D grid really are better for performance because doing // and % ops in the kernel is expensive
        + it indexes work items in a "row major order" meaning that items in the same row belong to the same sub group (/warp)
    + even if the previous information applies to cuda. I assume it's also true for numba-dpex/ sycl
- [x] also use 2D grids for kmeans kernels

It's WIP because the benchmark show that those changes induce a 30% performance overhead, there seem to be an issue with 2D grid of work items in `numba_dpex` or `SYCL`. 

Opened an issue https://github.com/IntelPython/numba-dpex/issues/941
TODO: find minimal reproducers.

This PR remains opened as WIP in case those issues are fixed eventually.

Before considering merging the PR, please rebase the branch and check if new kernels on main branch could also benefit from the change.
