### PR TITLE
Improve performance accross several kernels with better parameters

### DIFF
--- a/sklearn_numba_dpex/common/matmul.py
+++ b/sklearn_numba_dpex/common/matmul.py
@@ -106,7 +106,7 @@ def make_matmul_2d_kernel(
     - https://triton-lang.org/master/getting-started/tutorials/03-matrix-multiplication.html  # noqa
 
     """
-    if work_group_size in [None, "max"]:
+    if work_group_size is None:
         work_group_size = 512
     if sub_group_size is None:
         sub_group_size = 32

--- a/sklearn_numba_dpex/common/matmul.py
+++ b/sklearn_numba_dpex/common/matmul.py
@@ -174,7 +174,7 @@ def make_matmul_2d_kernel(
     if base_nb_results_per_work_item_log2 < 1:
         if base_nb_results_per_work_item_log2 % 2:
             result_window_height_multiplier_Y = 2 ** (
-                (1 - base_nb_results_per_work_item_log2) // 2
+                (-1 - base_nb_results_per_work_item_log2) // 2
             )
             result_window_height_multiplier_X = 2 * result_window_height_multiplier_Y
         else:

--- a/sklearn_numba_dpex/common/random.py
+++ b/sklearn_numba_dpex/common/random.py
@@ -33,7 +33,7 @@ def get_random_raw(states):
 
     Note, this always uses and updates state states[0].
     """
-    result = dpt.empty(sh=(1,), dtype=np.uint64, device=states.device)
+    result = dpt.empty((1,), dtype=np.uint64, device=states.device)
     make_random_raw_kernel()(states, result)
     return result
 
@@ -171,7 +171,7 @@ def create_xoroshiro128pp_states(n_states, subsequence_start=0, seed=None, devic
     ) = _get_sequential_processing_device(device)
 
     states = dpt.empty(
-        sh=(n_states, 2), dtype=np.uint64, device=sequential_processing_device
+        (n_states, 2), dtype=np.uint64, device=sequential_processing_device
     )
 
     seed = dpt.asarray([seed], dtype=np.uint64, device=sequential_processing_device)

--- a/sklearn_numba_dpex/common/reductions.py
+++ b/sklearn_numba_dpex/common/reductions.py
@@ -378,7 +378,7 @@ def make_sum_reduction_2d_kernel(
         if sum_axis_size == 0:
             # By convention the sum of all elements of an empty array is equal to 0. (
             # likewise with numpy np.sum([]) returns 0).
-            summands = dpt.zeros(sh=get_result_shape(1))
+            summands = dpt.zeros(get_result_shape(1))
 
         # TODO: manually dispatch the kernels with a SyclQueue
         for kernel, sizes, result in kernels_and_empty_tensors_pairs:

--- a/sklearn_numba_dpex/common/tests/test_matmul.py
+++ b/sklearn_numba_dpex/common/tests/test_matmul.py
@@ -50,9 +50,6 @@ def _test_matmul_2d(
 
     device = X.device.sycl_device
 
-    if sub_group_size is None:
-        sub_group_size = min(device.sub_group_sizes)
-
     matmul_2d_kernel = make_matmul_2d_kernel(
         X_n_rows,
         Y_t_n_rows,
@@ -73,7 +70,7 @@ def _test_matmul_2d(
 
 @pytest.mark.parametrize("array_fn", ["arange", "random"])
 @pytest.mark.parametrize(
-    "work_group_size, sub_group_size", [(1, 1), (4, 2), (16, 4), ("max", None)]
+    "work_group_size, sub_group_size", [(1, 1), (4, 2), (16, 4), (None, None)]
 )
 @pytest.mark.parametrize("dtype", [np.float32])
 @pytest.mark.parametrize(

--- a/sklearn_numba_dpex/common/tests/test_random.py
+++ b/sklearn_numba_dpex/common/tests/test_random.py
@@ -154,14 +154,14 @@ def test_rng_quality(dtype):
 def _get_single_rand_value(random_state, dtype):
     """Return a single rand value sampled uniformly in [0, 1)"""
     _get_single_rand_value_kernel = _make_get_single_rand_value_kernel(dtype)
-    single_rand_value = dpt.empty(sh=1, dtype=dtype)
+    single_rand_value = dpt.empty(1, dtype=dtype)
     _get_single_rand_value_kernel[1, 1](random_state, single_rand_value)
     return dpt.asnumpy(single_rand_value)[0]
 
 
 def _rand_uniform(size, dtype, seed, n_work_items=1000):
     """Return an array of floats sampled uniformly in [0, 1)"""
-    out = dpt.empty(sh=(size,), dtype=dtype)
+    out = dpt.empty((size,), dtype=dtype)
     work_group_size = out.device.sycl_device.max_work_group_size
     size_per_work_item = math.ceil(size / n_work_items)
 

--- a/sklearn_numba_dpex/common/topk.py
+++ b/sklearn_numba_dpex/common/topk.py
@@ -167,13 +167,13 @@ def topk(array_in, k, group_sizes=None):
         work_group_size,
     )
 
-    result = dpt.empty(sh=(n_rows, k), dtype=dtype, device=device)
+    result = dpt.empty((n_rows, k), dtype=dtype, device=device)
 
     # For each row, maintain an atomically incremented index of the next result value
     # to be stored:.
     # Note that the ordering of the topk is non-deteriminstic and dependents on the
     # concurrency of the parallel work items.
-    result_col_idx = dpt.zeros(sh=(n_rows,), dtype=np.int32, device=device)
+    result_col_idx = dpt.zeros((n_rows,), dtype=np.int32, device=device)
 
     gather_topk_kernel(
         array_in,
@@ -252,8 +252,8 @@ def topk_idx(array_in, k, group_sizes=None):
         work_group_size,
     )
 
-    result = dpt.empty(sh=(n_rows, k), dtype=np.int64, device=device)
-    result_col_idx = dpt.zeros(sh=(n_rows,), dtype=np.int32, device=device)
+    result = dpt.empty((n_rows, k), dtype=np.int64, device=device)
+    result_col_idx = dpt.zeros((n_rows,), dtype=np.int32, device=device)
 
     gather_topk_idx_kernel(
         array_in,
@@ -407,13 +407,13 @@ def _get_topk_threshold(array_in, k, group_sizes):
 
     # mask and value used to filter the subset of the data that is currently searched
     # at the given iteration
-    mask_for_desired_value = dpt.zeros(sh=(1,), dtype=uint_type, device=device)
-    desired_masked_value = dpt.zeros(sh=(n_rows,), dtype=uint_type, device=device)
+    mask_for_desired_value = dpt.zeros((1,), dtype=uint_type, device=device)
+    desired_masked_value = dpt.zeros((n_rows,), dtype=uint_type, device=device)
 
     # Buffer that stores the counts of occurences of the values at the current radix
     # position.
     privatized_counts = dpt.zeros(
-        sh=(n_counts_private_copies, n_rows, radix_size), dtype=np.int64, device=device
+        (n_counts_private_copies, n_rows, radix_size), dtype=np.int64, device=device
     )
 
     # Will store the number of occurences of the top-k threshold value in the data

--- a/sklearn_numba_dpex/common/topk.py
+++ b/sklearn_numba_dpex/common/topk.py
@@ -307,8 +307,8 @@ def _get_topk_threshold(array_in, k, group_sizes):
     ) = _make_create_radix_histogram_kernel(
         n_rows,
         n_cols,
-        "max" if group_sizes is None else work_group_size,
-        4 if group_sizes is None else sub_group_size,
+        64 if group_sizes is None else work_group_size,
+        16 if group_sizes is None else sub_group_size,
         global_mem_cache_size,
         counts_private_copies_max_cache_occupancy,
         dtype,

--- a/sklearn_numba_dpex/common/topk.py
+++ b/sklearn_numba_dpex/common/topk.py
@@ -324,7 +324,7 @@ def _get_topk_threshold(array_in, k, group_sizes):
         shape=(n_counts_private_copies, n_rows_x_radix_size),
         device=device,
         dtype=np.int64,
-        work_group_size=work_group_size,
+        work_group_size="max",
         axis=0,
         sub_group_size=sub_group_size,
     )

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -56,7 +56,7 @@ def lloyd(
 
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
-    sub_group_size = min(device.sub_group_sizes)
+    sub_group_size = 4
     global_mem_cache_size = _get_global_mem_cache_size(device)
 
     # The following parameter controls the fraction of the device global cache memory
@@ -623,9 +623,9 @@ def get_nb_distinct_clusters(labels, n_clusters):
         device=device,
     )
 
-    clusters_seen = dpt.zeros(sh=(n_clusters,), dtype=np.int32, device=device)
+    clusters_seen = dpt.zeros((n_clusters,), dtype=np.int32, device=device)
 
-    nb_distinct_clusters = dpt.zeros(sh=(1,), dtype=np.int32, device=device)
+    nb_distinct_clusters = dpt.zeros((1,), dtype=np.int32, device=device)
 
     get_nb_distinct_clusters_kernel(
         labels,
@@ -644,7 +644,7 @@ def get_labels_inertia(X_t, centroids_t, sample_weight, with_inertia):
     n_clusters = centroids_t.shape[1]
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
-    sub_group_size = min(device.sub_group_sizes)
+    sub_group_size = 4
 
     label_assignment_fixed_window_kernel = make_label_assignment_fixed_window_kernel(
         n_samples,
@@ -715,7 +715,7 @@ def get_euclidean_distances(X_t, Y_t):
     n_features, n_samples = X_t.shape
     n_clusters = Y_t.shape[1]
     device = X_t.device.sycl_device
-    sub_group_size = min(device.sub_group_sizes)
+    sub_group_size = 4
 
     euclidean_distances_fixed_window_kernel = (
         make_compute_euclidean_distances_fixed_window_kernel(
@@ -753,7 +753,7 @@ def kmeans_plusplus(
     n_features, n_samples = X_t.shape
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
-    sub_group_size = min(device.sub_group_sizes)
+    sub_group_size = 4
 
     # NB: the implementation differs from sklearn implementation with regards to
     # sample_weight, which is ignored in sklearn, but used here.
@@ -826,19 +826,17 @@ def kmeans_plusplus(
         compute_dtype,
     )
 
-    centers_t = dpt.empty(
-        sh=(n_features, n_clusters), dtype=compute_dtype, device=device
-    )
+    centers_t = dpt.empty((n_features, n_clusters), dtype=compute_dtype, device=device)
 
     center_indices = dpt.full((n_clusters,), -1, dtype=np.int32)
 
     sq_distances_t = dpt.empty(
-        sh=(n_local_trials, n_samples), dtype=compute_dtype, device=device
+        (n_local_trials, n_samples), dtype=compute_dtype, device=device
     )
 
-    closest_dist_sq = dpt.empty(sh=(n_samples,), dtype=compute_dtype, device=device)
+    closest_dist_sq = dpt.empty((n_samples,), dtype=compute_dtype, device=device)
 
-    candidate_ids = dpt.empty(sh=(n_local_trials,), dtype=np.int32, device=device)
+    candidate_ids = dpt.empty((n_local_trials,), dtype=np.int32, device=device)
 
     # Pick first center randomly
     # Use numpy type to work around https://github.com/IntelPython/dpnp/issues/1238

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -56,15 +56,8 @@ def lloyd(
 
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
-    sub_group_size = 4
+    sub_group_size = 8
     global_mem_cache_size = _get_global_mem_cache_size(device)
-
-    # The following parameter controls the fraction of the device global cache memory
-    # that can be relied upon to reduce the probability of collision of atomic
-    # ops during execution (see `lloyd_single_step` kernel for more information). The
-    # following value has been chosen empirically and it might be beneficial to test it
-    # further on different hardware.
-    centroids_private_copies_max_cache_occupancy = 0.7
 
     # Create a set of kernels
     (
@@ -82,7 +75,6 @@ def lloyd(
         check_strict_convergence=True,
         sub_group_size=sub_group_size,
         global_mem_cache_size=global_mem_cache_size,
-        centroids_private_copies_max_cache_occupancy=centroids_private_copies_max_cache_occupancy,  # noqa
         work_group_size="max",
         dtype=compute_dtype,
         device=device,
@@ -644,7 +636,7 @@ def get_labels_inertia(X_t, centroids_t, sample_weight, with_inertia):
     n_clusters = centroids_t.shape[1]
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
-    sub_group_size = 4
+    sub_group_size = 8
 
     label_assignment_fixed_window_kernel = make_label_assignment_fixed_window_kernel(
         n_samples,
@@ -715,7 +707,7 @@ def get_euclidean_distances(X_t, Y_t):
     n_features, n_samples = X_t.shape
     n_clusters = Y_t.shape[1]
     device = X_t.device.sycl_device
-    sub_group_size = 4
+    sub_group_size = 8
 
     euclidean_distances_fixed_window_kernel = (
         make_compute_euclidean_distances_fixed_window_kernel(
@@ -753,7 +745,7 @@ def kmeans_plusplus(
     n_features, n_samples = X_t.shape
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
-    sub_group_size = 4
+    sub_group_size = 8
 
     # NB: the implementation differs from sklearn implementation with regards to
     # sample_weight, which is ignored in sklearn, but used here.

--- a/sklearn_numba_dpex/kmeans/drivers.py
+++ b/sklearn_numba_dpex/kmeans/drivers.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from sklearn_numba_dpex.common._utils import (
     _divide_by,
-    _get_global_mem_cache_size,
     _get_sequential_processing_device,
     _minus,
     _plus,
@@ -57,7 +56,6 @@ def lloyd(
     device = X_t.device.sycl_device
     max_work_group_size = device.max_work_group_size
     sub_group_size = 8
-    global_mem_cache_size = _get_global_mem_cache_size(device)
 
     # Create a set of kernels
     (
@@ -74,7 +72,6 @@ def lloyd(
         return_assignments=True,
         check_strict_convergence=True,
         sub_group_size=sub_group_size,
-        global_mem_cache_size=global_mem_cache_size,
         work_group_size="max",
         dtype=compute_dtype,
         device=device,

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -39,7 +39,6 @@ def make_lloyd_single_step_fixed_window_kernel(
     return_assignments,
     check_strict_convergence,
     sub_group_size,
-    centroids_private_copies_max_cache_occupancy,
     work_group_size,
     dtype,
     device,

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -39,7 +39,6 @@ def make_lloyd_single_step_fixed_window_kernel(
     return_assignments,
     check_strict_convergence,
     sub_group_size,
-    global_mem_cache_size,
     centroids_private_copies_max_cache_occupancy,
     work_group_size,
     dtype,

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -111,22 +111,9 @@ def make_lloyd_single_step_fixed_window_kernel(
 
     n_subgroups = math.ceil(n_samples / window_n_centroids)
 
-    n_cluster_items = n_clusters * (n_features + 1)
-    n_cluster_bytes = np.dtype(dtype).itemsize * n_cluster_items
-    # TODO: control that this value is not higher than the number of sub-groups of size
-    # sub_group_size that can effectively run concurrently. We should fetch this
-    # information and apply it here.
-
     # NB: for more details about the privatization strategy the following variables
     # refer too, please read the inline commenting that address it in the kernel
     # definition.
-
-    # Ensure that the memory allocated for privatization will not saturate the global
-    # memory cache size. For this purpose we limit the number of private copies to
-    # a fraction of the available global memory cache size.
-    n_centroids_private_copies = (
-        global_mem_cache_size * centroids_private_copies_max_cache_occupancy
-    ) // n_cluster_bytes
 
     # Each set of `sub_group_size` consecutive work items is assigned one private
     # copy, and several such sets can be assigned to the same private copy. Thus, at
@@ -139,12 +126,10 @@ def make_lloyd_single_step_fixed_window_kernel(
     # that highlight complexity of the execution model:
     # - https://github.com/IntelPython/dpctl/issues/1033
     # - https://stackoverflow.com/a/6490897
-    n_centroids_private_copies = int(
-        min(n_subgroups, n_centroids_private_copies, device.max_compute_units)
-    )
+    n_centroids_private_copies = int(min(n_subgroups, device.max_compute_units))
 
     # Safety check for edge case where `n_centroids_private_copies` equals 0 because
-    # `n_cluster_bytes` is too large
+    # `n_samples` is null.
     n_centroids_private_copies = max(n_centroids_private_copies, 1)
 
     zero_idx = np.int64(0)

--- a/sklearn_numba_dpex/kmeans/kernels/utils.py
+++ b/sklearn_numba_dpex/kmeans/kernels/utils.py
@@ -205,7 +205,7 @@ def make_is_same_clustering_kernel(n_samples, n_clusters, work_group_size, devic
     # - early stop
 
     def is_same_clustering(labels1, labels2):
-        mapping = dpt.empty(sh=(n_clusters,), dtype=np.int32, device=device)
+        mapping = dpt.empty((n_clusters,), dtype=np.int32, device=device)
         result = dpt.asarray([1], dtype=np.int32, device=device)
         _build_mapping[global_size, work_group_size](labels1, labels2, mapping)
         _is_same_clustering[global_size, work_group_size](

--- a/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
+++ b/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
@@ -416,7 +416,6 @@ def test_error_raised_on_invalid_group_sizes():
 
     return_assignments = False
     check_strict_convergence = False
-    global_mem_cache_size = 123456789
 
     with pytest.raises(ValueError, match=expected_msg):
         make_lloyd_single_step_fixed_window_kernel(
@@ -426,7 +425,6 @@ def test_error_raised_on_invalid_group_sizes():
             return_assignments,
             check_strict_convergence,
             sub_group_size,
-            global_mem_cache_size,
             work_group_size,
             dtype,
             device,

--- a/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
+++ b/sklearn_numba_dpex/kmeans/tests/test_kmeans.py
@@ -417,7 +417,6 @@ def test_error_raised_on_invalid_group_sizes():
     return_assignments = False
     check_strict_convergence = False
     global_mem_cache_size = 123456789
-    centroids_private_copies_max_cache_occupancy = 0.7
 
     with pytest.raises(ValueError, match=expected_msg):
         make_lloyd_single_step_fixed_window_kernel(
@@ -428,7 +427,6 @@ def test_error_raised_on_invalid_group_sizes():
             check_strict_convergence,
             sub_group_size,
             global_mem_cache_size,
-            centroids_private_copies_max_cache_occupancy,
             work_group_size,
             dtype,
             device,

--- a/sklearn_numba_dpex/patches/tests/test_patches.py
+++ b/sklearn_numba_dpex/patches/tests/test_patches.py
@@ -37,7 +37,7 @@ def test_need_to_workaround_numba_dpex_906():
         if local_idx < 1:
             result[0] = 10
 
-    result = dpt.zeros(sh=(1), dtype=dtype, device=dpctl.SyclDevice("cpu"))
+    result = dpt.zeros((1), dtype=dtype, device=dpctl.SyclDevice("cpu"))
     kernel[32, 32](result)
 
     rationale = """If this test fails, it means that the bug reported at
@@ -62,7 +62,7 @@ def test_need_to_workaround_numba_dpex_906():
 
     _setitem_if = make_setitem_if_kernel_func()
 
-    result = dpt.zeros(sh=(1), dtype=dtype, device=dpctl.SyclDevice("cpu"))
+    result = dpt.zeros((1), dtype=dtype, device=dpctl.SyclDevice("cpu"))
     kernel[32, 32](result)
 
     assert dpt.asnumpy(result)[0] == 10


### PR DESCRIPTION
With this PR:

- <del>our matmul achieves 90% dpnp performance on iGPU</del> See: https://github.com/soda-inria/sklearn-numba-dpex/pull/107#issuecomment-1519389111.
- catastrophic performances on max series gpu is fixed of KMeans

also fix compatibility with latest versions of `dpctl`.

Closes https://github.com/IntelPython/numba-dpex/issues/984