### PR TITLE
Assume private arrays are created already initialized to zero

### DIFF
--- a/sklearn_numba_dpex/common/matmul.py
+++ b/sklearn_numba_dpex/common/matmul.py
@@ -328,8 +328,6 @@ def make_matmul_2d_kernel(
             work_item_idx % nb_work_items_for_Y_t_window
         )
 
-        _initialize_private_result(private_result)
-
         work_item_col_idx_padded = two_as_long * work_item_col_idx
         first_X_loaded_row_idx = group_first_row_idx + work_item_row_idx
         first_Y_t_loaded_row_idx = group_first_col_idx + work_item_row_idx
@@ -373,12 +371,6 @@ def make_matmul_2d_kernel(
             # OUT
             result
         )
-
-    @dpex.func
-    def _initialize_private_result(private_result):
-        for i in range(private_result_array_height):
-            for j in range(private_result_array_width):
-                private_result[i, j] = zero
 
     # HACK 906: see sklearn_numba_dpex.patches.tests.test_patches.test_need_to_workaround_numba_dpex_906  # noqa
     @dpex.func

--- a/sklearn_numba_dpex/common/matmul.py
+++ b/sklearn_numba_dpex/common/matmul.py
@@ -304,6 +304,9 @@ def make_matmul_2d_kernel(
             shape=local_Y_t_sliding_window_shape, dtype=dtype
         )
 
+        # NB: private arrays are assumed to be created already initialized with
+        # zero values
+
         # Allocate private memory for the result window
         private_result = dpex.private.array(
             shape=thread_private_result_array_shape, dtype=dtype

--- a/sklearn_numba_dpex/common/topk.py
+++ b/sklearn_numba_dpex/common/topk.py
@@ -681,6 +681,8 @@ def _make_create_radix_histogram_kernel(
         )
 
         # Initialize private memory
+        # NB: private arrays are assumed to be created already initialized with
+        # zero values
         private_counts = dpex.private.array(sub_group_size, dtype=histogram_dtype)
 
         # Compute the radix value of `array_in_uint` at location `(row_idx, col_idx)`,

--- a/sklearn_numba_dpex/common/topk.py
+++ b/sklearn_numba_dpex/common/topk.py
@@ -682,7 +682,6 @@ def _make_create_radix_histogram_kernel(
 
         # Initialize private memory
         private_counts = dpex.private.array(sub_group_size, dtype=histogram_dtype)
-        initialize_private_histograms(private_counts)
 
         # Compute the radix value of `array_in_uint` at location `(row_idx, col_idx)`,
         # and store it in `radix_values[local_subgroup, local_subgroup_work_id]`. If
@@ -829,11 +828,6 @@ def _make_create_radix_histogram_kernel(
             value = histogram_dtype(minus_one_idx)
 
         radix_values[local_subgroup, local_subgroup_work_id] = value
-
-    @dpex.func
-    def initialize_private_histograms(private_counts):
-        for i in range(sub_group_size):
-            private_counts[i] = zero_idx
 
     # The `compute_private_histogram` function is written differently depending on how
     # the number of histogram work items compare to the size of the sub groups.

--- a/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_euclidean_distances.py
@@ -37,7 +37,6 @@ def make_compute_euclidean_distances_fixed_window_kernel(
     work_group_shape = (window_n_centroids, centroids_window_height)
 
     (
-        initialize_window_of_centroids,
         load_window_of_centroids_and_features,
         accumulate_sq_distances,
     ) = make_pairwise_ops_base_kernel_funcs(
@@ -88,7 +87,6 @@ def make_compute_euclidean_distances_fixed_window_kernel(
 
         for centroid_window_idx in range(n_windows_for_centroids):
             is_last_centroid_window = centroid_window_idx == last_centroid_window_idx
-            initialize_window_of_centroids(is_last_centroid_window, sq_distances)
 
             loading_centroid_idx = first_centroid_idx + window_loading_centroid_idx
 

--- a/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
@@ -43,9 +43,9 @@ def make_label_assignment_fixed_window_kernel(
     work_group_shape = (window_n_centroids, centroids_window_height)
 
     (
-        initialize_window_of_centroids,
         load_window_of_centroids_and_features,
         accumulate_dot_products,
+        initialize_window_half_l2_norm,
     ) = make_pairwise_ops_base_kernel_funcs(
         n_samples,
         n_features,
@@ -105,7 +105,7 @@ def make_label_assignment_fixed_window_kernel(
         for centroid_window_idx in range(n_windows_for_centroids):
             is_last_centroid_window = centroid_window_idx == last_centroid_window_idx
 
-            initialize_window_of_centroids(
+            initialize_window_half_l2_norm(
                 local_row_idx,
                 local_col_idx,
                 first_centroid_idx,

--- a/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
+++ b/sklearn_numba_dpex/kmeans/kernels/compute_labels.py
@@ -112,7 +112,6 @@ def make_label_assignment_fixed_window_kernel(
                 centroids_half_l2_norm,
                 is_last_centroid_window,
                 window_of_centroids_half_l2_norms,
-                dot_products,
             )
 
             loading_centroid_idx = first_centroid_idx + window_loading_centroid_idx

--- a/sklearn_numba_dpex/kmeans/kernels/kmeans_plusplus.py
+++ b/sklearn_numba_dpex/kmeans/kernels/kmeans_plusplus.py
@@ -128,7 +128,6 @@ def make_kmeansplusplus_single_step_fixed_window_kernel(
     work_group_shape = (window_n_candidates, candidates_window_height)
 
     (
-        initialize_window_of_candidates,
         load_window_of_candidates_and_features,
         accumulate_sq_distances,
     ) = make_pairwise_ops_base_kernel_funcs(
@@ -180,7 +179,6 @@ def make_kmeansplusplus_single_step_fixed_window_kernel(
 
         for candidate_window_idx in range(n_windows_for_candidates):
             is_last_candidate_window = candidate_window_idx == last_candidate_window_idx
-            initialize_window_of_candidates(is_last_candidate_window, sq_distances)
 
             loading_candidate_idx = first_candidate_idx + window_loading_candidate_idx
             if loading_candidate_idx < n_candidates:

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -84,9 +84,9 @@ def make_lloyd_single_step_fixed_window_kernel(
     work_group_shape = (window_n_centroids, centroids_window_height)
 
     (
-        initialize_window_of_centroids,
         load_window_of_centroids_and_features,
         accumulate_dot_products,
+        initialize_window_half_l2_norm,
     ) = make_pairwise_ops_base_kernel_funcs(
         n_samples,
         n_features,
@@ -264,7 +264,7 @@ def make_lloyd_single_step_fixed_window_kernel(
             # window_of_centroids_half_l2_norms and dot_products
             # are modified in place.
             is_last_centroid_window = centroid_window_idx == last_centroid_window_idx
-            initialize_window_of_centroids(
+            initialize_window_half_l2_norm(
                 local_row_idx,
                 local_col_idx,
                 first_centroid_idx,

--- a/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
+++ b/sklearn_numba_dpex/kmeans/kernels/lloyd_single_step.py
@@ -272,7 +272,6 @@ def make_lloyd_single_step_fixed_window_kernel(
                 is_last_centroid_window,
                 # OUT
                 window_of_centroids_half_l2_norms,
-                dot_products,
             )
 
             loading_centroid_idx = first_centroid_idx + window_loading_centroid_idx


### PR DESCRIPTION
The initialization step in lloyd seemed to cause buggy behavior and a huge slowdown for some dimensions in inputs on PVC.

I didn't have time to reproduce within the timed access to the server but I experimented with removing the initialization step and found out that it seems to work just fine. 

This PR remove all initialization funcs for private arrays in all kernels.

I've opened a subsequent issues to inquiry the validity of this assumption at https://github.com/IntelPython/numba-dpex/issues/1016